### PR TITLE
[Feat-7] course 조회

### DIFF
--- a/src/main/java/icurriculum/domain/course/dto/CourseSearchResponseDTO.java
+++ b/src/main/java/icurriculum/domain/course/dto/CourseSearchResponseDTO.java
@@ -1,0 +1,13 @@
+package icurriculum.domain.course.dto;
+
+import icurriculum.domain.course.Course;
+import icurriculum.domain.take.Category;
+import lombok.Builder;
+
+@Builder
+public class CourseSearchResponseDTO {
+    private Long courseId;
+    private String name;
+    private Integer credit;
+    private String category;
+}

--- a/src/main/java/icurriculum/domain/course/service/CourseService.java
+++ b/src/main/java/icurriculum/domain/course/service/CourseService.java
@@ -1,13 +1,21 @@
 package icurriculum.domain.course.service;
 
+import icurriculum.domain.categoryjudge.CategoryJudgeUtils;
+import icurriculum.domain.categoryjudge.CategoryJudgeUtilsImpl;
 import icurriculum.domain.course.Course;
+import icurriculum.domain.course.dto.CourseSearchResponseDTO;
 import icurriculum.domain.course.repository.CourseRepository;
+import icurriculum.domain.curriculum.Curriculum;
+import icurriculum.domain.curriculum.service.CurriculumService;
+import icurriculum.domain.member.Member;
+import icurriculum.domain.membermajor.MemberMajor;
+import icurriculum.domain.membermajor.service.MemberMajorService;
+import icurriculum.domain.take.Category;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +23,9 @@ import java.util.Set;
 public class CourseService {
 
     private final CourseRepository repository;
+    private final CurriculumService curriculumService;
+    private final CategoryJudgeUtils categoryJudgeUtils;
+    private final MemberMajorService memberMajorService;
 
     public List<Course> findCoursesByCodes(Set<String> codes) {
         return repository.findByCodes(codes);
@@ -26,5 +37,22 @@ public class CourseService {
         /**
          * TODO 예외 추후 정의
          */
+    }
+
+    public CourseSearchResponseDTO getCourse(Member member, String code) {
+        List<MemberMajor> majorsByMember = memberMajorService.findMajorsByMember(member);
+        Curriculum curriculum = curriculumService.findCurriculumByMemberMajor(majorsByMember);
+        Optional<Course> course = repository.findByCode(code);
+        if(course.isEmpty()) throw new RuntimeException("해당 과목이 없습니다.");
+        Course findCourse = course.get();
+        ArrayList<String> codes = new ArrayList<>();
+        codes.add(code);
+        Map<String, Category> judgedCodes = categoryJudgeUtils.judge(codes, curriculum);
+        return CourseSearchResponseDTO.builder()
+                .courseId(findCourse.getId())
+                .name(findCourse.getName())
+                .credit(findCourse.getCredit())
+                .category(judgedCodes.get(code).toString())
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
> course 단일 조회 기능 추가
## 📝 작업 내용
> 기존 CourseService에 단일 조회하는 함수 getCourse 함수 추가했습니다.

```java
// 핵심 코드를 붙여넣기 해주세요
public CourseSearchResponseDTO getCourse(Member member, String code) {
        List<MemberMajor> majorsByMember = memberMajorService.findMajorsByMember(member);
        Curriculum curriculum = curriculumService.findCurriculumByMemberMajor(majorsByMember);
        Optional<Course> course = repository.findByCode(code);
        if(course.isEmpty()) throw new RuntimeException("해당 과목이 없습니다.");
        Course findCourse = course.get();
        ArrayList<String> codes = new ArrayList<>();
        codes.add(code);
        Map<String, Category> judgedCodes = categoryJudgeUtils.judge(codes, curriculum);
        return CourseSearchResponseDTO.builder()
                .courseId(findCourse.getId())
                .name(findCourse.getName())
                .credit(findCourse.getCredit())
                .category(judgedCodes.get(code).toString())
                .build();
    }
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진
> 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
