### PR TITLE
[Feat-25] Category 판별 로직 생성

### DIFF
--- a/src/main/java/icurriculum/domain/CategoryJudge/CategoryJudgeUtils.java
+++ b/src/main/java/icurriculum/domain/CategoryJudge/CategoryJudgeUtils.java
@@ -1,0 +1,11 @@
+package icurriculum.domain.categoryjudge;
+
+import icurriculum.domain.curriculum.Curriculum;
+import icurriculum.domain.take.Category;
+
+import java.util.List;
+import java.util.Map;
+
+public interface CategoryJudgeUtils {
+    Map<String,Category> judge(List<String> codes, Curriculum curriculum);
+}

--- a/src/main/java/icurriculum/domain/CategoryJudge/CategoryJudgeUtilsImpl.java
+++ b/src/main/java/icurriculum/domain/CategoryJudge/CategoryJudgeUtilsImpl.java
@@ -1,0 +1,169 @@
+package icurriculum.domain.categoryjudge;
+
+import icurriculum.domain.curriculum.Curriculum;
+import icurriculum.domain.curriculum.json.*;
+import icurriculum.domain.take.Category;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class CategoryJudgeUtilsImpl implements CategoryJudgeUtils {
+    @Override
+    public Map<String, Category> judge(List<String> codes, Curriculum curriculum) {
+
+        Map<String, Category> judgeCodes = new HashMap<>();
+
+        CurriculumCodesJson curriculumCodesJson = curriculum.getCurriculumCodesJson(); // 교과과정
+
+        Set<String> eMajor = curriculumCodesJson.findCodesByCategory(Category.전공필수);
+        Set<String> cMajor = curriculumCodesJson.findCodesByCategory(Category.전공선택);
+        Set<String> eGyo = curriculumCodesJson.findCodesByCategory(Category.교양필수);
+
+        Set<String> creativityCodes = curriculum.getCreativityJson().getConfirmedCodes(); // 창의 영역 지정과목
+
+        Set<String> swAiCodes = curriculum.getSwAiJson().getConfirmedCodes();
+        Set<String> swAialternativeCodes = curriculum.getSwAiJson().getAlternativeCodes();
+
+        Map<String, Set<String>> alternativeCourseMap = curriculum.getAlternativeCourseJson().getAlternativeCourseMap();
+
+        for (String code : codes) {
+            Category category = judgeCore(code, curriculum);  // 핵심교양 판단
+            if (isCoreCode(category)) {
+                judgeCodes.put(code, category);
+            } else { // 핵심교양이 아닌 과목들의 다른영역 확인
+                if (creativityCodes != null && creativityCodes.contains(code)) {
+                    judgeCodes.put(code, Category.창의);
+                } else if (((swAiCodes != null && swAiCodes.contains(code)) || (swAialternativeCodes != null && swAialternativeCodes.contains(code)))) {
+                    judgeCodes.put(code, Category.SW_AI);
+                } else if (eMajor.contains(code)) {
+                    judgeCodes.put(code, Category.전공필수);
+                } else if (cMajor.contains(code)) {
+                    judgeCodes.put(code, Category.전공선택);
+                } else if (eGyo.contains(code)) {
+                    judgeCodes.put(code, Category.교양필수);
+                } else {
+                    if (alternativeCourseMap.containsKey(code)) {
+                        judgeCodes.put(code, judgeAlternative(alternativeCourseMap.get(code), curriculum));
+                    } else {
+                        judgeCodes.put(code, Category.교양선택);
+                    }
+                }
+            }
+
+        }
+        return judgeCodes;
+    }
+
+    /**
+     * 사용자 핵심교양 판별 메서드
+     *
+     * @return 핵심교양 영역
+     **/
+    public Category judgeCore(String code, Curriculum curriculum) {
+
+        CoreJson coreJson = curriculum.getCoreJson(); // 핵심교양
+        Boolean isAreaConfirmed = coreJson.getIsAreaConfirmed(); // 지정 영역이있는지 확인
+        Set<Category> requiredAreas = coreJson.getRequiredAreas(); // 핵심교양 영역 리스트
+        Map<Category, Set<String>> confirmedCodesByArea = coreJson.getConfirmedCodesByArea(); // 지정 영역 리스트
+        Map<Category, Set<String>> alternativeCodesByArea = coreJson.getAlternativeCodesByArea(); //영역별 대체 리스트
+
+        Set<String> alternativeCoreCodes = null;
+        if (alternativeCodesByArea != null) {
+            alternativeCoreCodes = alternativeCodesByArea.get(Category.핵심교양6);
+        }
+        Category category;
+
+        if (code.startsWith("GEC") || code.startsWith("GED")) {
+            char coreArea = code.charAt(3); // 핵교 영역
+            switch (coreArea) {
+                case '1' -> category = Category.핵심교양1;
+                case '2' -> category = Category.핵심교양2;
+                case '3' -> category = Category.핵심교양3;
+                case '4' -> category = Category.핵심교양4;
+                case '5' -> category = Category.핵심교양5;
+                case '6' -> category = Category.핵심교양6;
+                default -> category = Category.교양선택;
+            }
+        } else if (alternativeCoreCodes != null && alternativeCoreCodes.contains(code)) {
+            return Category.핵심교양6;
+        } else {
+            if (confirmedCodesByArea != null) {
+                for (Category tempCategory : confirmedCodesByArea.keySet()) {
+                    Set<String> strings = confirmedCodesByArea.get(tempCategory);
+                    if (strings.contains(code)) return tempCategory;
+                }
+            }
+            return Category.교양선택;
+        }
+        if (!isAreaConfirmed) {
+            if (confirmedCodesByArea != null && confirmedCodesByArea.containsKey(category)) {
+                if (confirmedCodesByArea.get(category).contains(code)) {
+                    return category;
+                } else {
+                    return Category.교양선택;
+                }
+            } else {
+                return category;
+            }
+        } else {
+            if (requiredAreas.contains(category)) {
+                if (confirmedCodesByArea.containsKey(category)) {
+                    if (confirmedCodesByArea.get(category).contains(code)) {
+                        return category;
+                    } else {
+                        return Category.교양선택;
+                    }
+                } else {
+                    return category;
+                }
+            }
+        }
+
+        return Category.교양선택;
+    }
+
+    public Boolean isCoreCode(Category category) {
+        return !category.equals(Category.교양선택);
+    }
+
+
+    public Category judgeAlternative(Set<String> codes, Curriculum curriculum) {
+        /**
+         * @params codes : 해당과목의 대체가능한 과목들
+         */
+        CurriculumCodesJson curriculumCodesJson = curriculum.getCurriculumCodesJson(); // 교과과정
+
+        Set<String> eMajor = curriculumCodesJson.findCodesByCategory(Category.전공필수);
+        Set<String> cMajor = curriculumCodesJson.findCodesByCategory(Category.전공선택);
+        Set<String> eGyo = curriculumCodesJson.findCodesByCategory(Category.교양필수);
+
+        Set<String> creativityCodes = curriculum.getCreativityJson().getConfirmedCodes();
+
+        Set<String> swAiCodes = curriculum.getSwAiJson().getConfirmedCodes();
+        Set<String> swAialternativeCodes = curriculum.getSwAiJson().getAlternativeCodes();
+
+
+        for (String code : codes) {
+            Category category = judgeCore(code, curriculum);  // 핵심교양 판단
+            if (isCoreCode(category)) {
+                return category;
+            } else { // 핵심교양이 아닌 과목들의 다른영역 확인
+                if (creativityCodes != null && creativityCodes.contains(code)) {
+                    return Category.창의;
+                } else if (((swAiCodes != null && swAiCodes.contains(code)) || (swAialternativeCodes != null && swAialternativeCodes.contains(code)))) {
+                    return Category.SW_AI;
+                } else if (eMajor.contains(code)) {
+                    return Category.전공필수;
+                } else if (cMajor.contains(code)) {
+                    return Category.전공선택;
+                } else if (eGyo.contains(code)) {
+                    return Category.교양필수;
+                }
+            }
+        }
+        return Category.교양선택;
+    }
+
+}


### PR DESCRIPTION
CategoryJudgeUtilsImpl 내의 judge 함수 실행시 파라미터로 넣은 code들에 대한 code,Category key-value Map을 반환

Resolves: #25

## #️⃣ 요약 설명
학수번호를 받아 각각 카테고리를 판별하여 반환하는 로직 
## 📝 작업 내용
> 사용자의 전공을 기준으로  전공필수, 전공선택, 핵심교양, 창의, SWAI, 교양필수, 교양선택 등으로 분류
> 전공 커리큘럼에 저장되어있는 대체과목들도 확인함


```java
for (String code : codes) {
            Category category = judgeCore(code, curriculum);  // 핵심교양 판단
            if (isCoreCode(category)) {
                judgeCodes.put(code, category);
            } else { // 핵심교양이 아닌 과목들의 다른영역 확인
                if (creativityCodes != null && creativityCodes.contains(code)) {
                    judgeCodes.put(code, Category.창의);
                } else if (((swAiCodes != null && swAiCodes.contains(code)) || (swAialternativeCodes != null && swAialternativeCodes.contains(code)))) {
                    judgeCodes.put(code, Category.SW_AI);
                } else if (eMajor.contains(code)) {
                    judgeCodes.put(code, Category.전공필수);
                } else if (cMajor.contains(code)) {
                    judgeCodes.put(code, Category.전공선택);
                } else if (eGyo.contains(code)) {
                    judgeCodes.put(code, Category.교양필수);
                } else {
                    if (alternativeCourseMap.containsKey(code)) {
                        judgeCodes.put(code, judgeAlternative(alternativeCourseMap.get(code), curriculum));
                    } else {
                        judgeCodes.put(code, Category.교양선택);
                    }
                }
            }

        }
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 