### PR TITLE
[FEAT-28] ProcessorResponse 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,3 +274,254 @@ commit convention을 문서화 하였습니다.
 
 Resolves: #10
 ```
+
+
+---
+## 응답 및 예외 전략
+
+### 📜 ApiResponse Class
+
+**ApiResponse 클래스 정의**
+```java
+public record ApiResponse<T>(
+    Boolean isSuccess,
+    String code,
+    String message,
+    T result) {
+...
+```
+
+* **Record 타입**: 이 클래스는 Java 14의 **Record** 타입으로 정의되었습니다. Record는 **불변 데이터 클래스**로 주로 데이터 전송 객체(DTO)를 단순하게 생성할 때 사용됩니다.
+* **Generics 사용 (****<T>****)**: 응답이 다양한 데이터 타입을 가질 수 있도록 제네릭 타입 매개변수 T를 사용하고 있습니다.
+* **필드 설명**:
+    * `Boolean isSuccess`: 요청의 성공 여부를 나타냅니다.
+    * `String code`: 응답 상태를 나타내는 코드입니다. 응답 코드를 담습니다.
+    * `String message`: 응답에 대한 메시지입니다. 주로 응답에 대한 설명을 저장합니다.
+    * `T result`: 응답의 결과 데이터를 포함합니다. 결과는 제네릭 타입으로 지정되어 있어 다양한 유형의 데이터를 담을 수 있습니다.
+
+
+**상수 및 메서드**
+
+```java
+public static final ApiResponse<Void> OK = new ApiResponse<>(true, SuccessStatus.OK.getCode(), SuccessStatus.OK.getMessage(), null);
+
+```
+
+* **OK** **상수**: OK는 성공적인 응답을 나타내는 **정적 상수**로, 아무런 결과 데이터(result)가 없을 때 사용됩니다.
+    * 성공 시, 전달하고 싶은 데이터가 없을 때 Controller에서 `return ApiResponse.OK` 작성합니다.
+
+
+```java
+public static <T> ApiResponse<T> onSuccess(T result) {
+    return new ApiResponse<>(true, SuccessStatus.OK.getCode(), SuccessStatus.OK.getMessage(),
+        result);
+}
+
+```
+* **onSuccess** **메서드**: 성공적인 응답을 생성하기 위한 **정적 팩토리 메서드**입니다.
+    * **매개변수**: 성공적인 결과 데이터 (result).
+    * **반환 값**: isSuccess가 true이고, 상태 코드는 성공 상태 (SuccessStatus.OK)인 ApiResponse 객체를 반환합니다.
+
+
+```java
+public static <T> ApiResponse<T> onFailure(ErrorStatus errorStatus, T data) {
+    return new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), data);
+}
+
+```
+
+* **onFailure** **메서드**: 오류 응답을 생성하기 위한 **정적 팩토리 메서드**입니다.
+    * **매개변수**: 오류 상태 (errorStatus)와 추가적인 결과 데이터 (data).
+    * **반환 값**: isSuccess가 false이고, 오류 상태 코드 및 메시지를 가지는 ApiResponse 객체를 반환합니다.
+    * 보통 ExceptionHandler에서 사용하게 될 메서드 입니다.
+
+
+### 📜 ErrorStatus Class
+⠀
+```java
+@Getter
+@RequiredArgsConstructor
+public enum ErrorStatus {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+
+...
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}
+
+```
+
+- ErrorStatus 클래스는 애플리케이션의 오류 상태를 관리하기 위한 **열거형(enum)**입니다.
+
+* **필드**
+    * `HttpStatus httpStatus`: HTTP 상태 코드를 나타냅니다. 새로 생성할 시, 컨벤션에 맞춰 400으로 통일합니다.
+    * `String code`: 커스텀 오류 코드를 정의합니다.
+    * `String message`: 사용자에게 표시할 오류 메시지입니다.
+- **사용법**
+    - 비즈니스적 오류가 발생하여 런타임 예외를 개발자가 발생시키고 싶거나, 체크 예외를 catch해서 런타임예외로 바꾸고 싶다면 ErrorStatus 클래스 내에 새로운 데이터를 정의하고 이를 GeneralException 클래스에 담아서 throw 합니다.
+
+
+### 📜 GeneralException Class
+
+```java
+@Getter
+public class GeneralException extends RuntimeException {
+
+    private final ErrorStatus errorStatus;
+    private final Object data;
+
+    public GeneralException(ErrorStatus errorStatus) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+        this.data = null;
+    }
+
+    public GeneralException(ErrorStatus errorStatus, Object data) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+        this.data = data;
+    }
+
+    public GeneralException(ErrorStatus errorStatus, Throwable cause) {
+        super(errorStatus.getMessage(), cause);
+        this.errorStatus = errorStatus;
+        this.data = null;
+    }
+
+    public GeneralException(ErrorStatus errorStatus, Object data, Throwable cause) {
+        super(errorStatus.getMessage(), cause);
+        this.errorStatus = errorStatus;
+        this.data = data;
+    }
+}
+
+
+```
+
+- GeneralException 클래스는 애플리케이션에서 발생할 수 있는 예외를 처리하기 위해 정의된 **사용자 정의 예외 클래스**입니다. 이 클래스는 **런타임 예외 (RuntimeException)**를 상속받아, 런타임에서 발생하는 오류를 다룹니다. 클래스 구성은 다음과 같습니다:
+
+**필드**
+```java
+private final ErrorStatus errorStatus;
+private final Object data;
+```
+
+* `ErrorStatus errorStatus`: 발생한 오류의 상태를 나타내는 **ErrorStatus** 객체입니다.
+* `Object data`: 예외 발생 시 추가적인 정보를 전달할 수 있는 데이터입니다.
+
+
+**생성자**
+```java
+public GeneralException(ErrorStatus errorStatus) {
+    super(errorStatus.getMessage());
+    this.errorStatus = errorStatus;
+    this.data = null;
+}
+
+public GeneralException(ErrorStatus errorStatus, Object data) {
+    super(errorStatus.getMessage());
+    this.errorStatus = errorStatus;
+    this.data = data;
+}
+
+public GeneralException(ErrorStatus errorStatus, Throwable cause) {
+    super(errorStatus.getMessage(), cause);
+    this.errorStatus = errorStatus;
+    this.data = null;
+}
+
+public GeneralException(ErrorStatus errorStatus, Object data, Throwable cause) {
+    super(errorStatus.getMessage(), cause);
+    this.errorStatus = errorStatus;
+    this.data = data;
+}
+
+
+```
+
+* **첫 번째 생성자**: ErrorStatus만 받아서 예외를 생성하며, 추가 데이터는 null로 설정합니다.
+* **두 번째 생성자**: ErrorStatus와 함께 추가 데이터를 받아 예외를 생성합니다.
+* **세 번째 생성자**: ErrorStatus와 **발생 원인 (cause)**을 받아 예외를 생성합니다. 예외 발생 원인을 포함하여 추적이 가능하도록 합니다.
+* **네 번째 생성자**: ErrorStatus, 에러 데이터 (data), 그리고 발생 원인 (cause)를 모두 받아 예외를 생성합니다.
+
+
+### 사용 예시
+
+**단순한 오류 상태만 사용하여 예외 생성**
+```java
+throw new GeneralException(ErrorStatus.BAD_REQUEST);
+```
+
+**추가 데이터와 함께 예외 생성**
+```java
+throw new GeneralException(ErrorStatus.MEMBER_MAJOR_NOT_FOUND, this);
+```
+- 비즈니스적 에러가 발생 시 해당 방식을 권장합니다.
+
+**발생 원인 (****cause****)과 함께 예외 생성**
+```java
+try {
+    ...
+} catch (Exception e) {
+    throw new GeneralException(ErrorStatus.INTERNAL_SERVER_ERROR, e);
+}
+
+```
+- **발생 원인**을 포함하여 GeneralException을 던져 예외 추적이 가능합니다.
+- 체크 예외를 언체크 예외로 전환할 때, **반드시 예외를 포함해서 던지도록 합니다.**
+
+**발생 원인 (cause), 데이터와 함께 예외 생성**
+```java
+try {
+    ...
+} catch (Exception e) {
+    throw new GeneralException(ErrorStatus.INTERNAL_SERVER_ERROR, this, e);
+}
+
+```
+
+⠀
+
+## 📜 GlobalExceptionHandler
+```java
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Object>> handleGeneralException(GeneralException ex) {
+        log.error("Error Code: {}, Message: {}, Data: {}",
+            ex.getErrorStatus().getCode(),
+            ex.getErrorStatus().getMessage(),
+            ex.getData() != null ? ex.getData() : "No additional data",
+            ex
+        );
+
+        return ResponseEntity
+            .status(ex.getErrorStatus().getHttpStatus())
+            .body(ApiResponse.onFailure(
+                ex.getErrorStatus(),
+                ex.getData()
+            ));
+    }
+}
+
+```
+
+- **로깅**
+    * Error Code: 예외의 상태 코드 (ErrorStatus에 정의된 코드).
+    * Message: 예외의 메시지.
+    * Data: 추가적인 오류 데이터, 없을 경우 "No additional data"로 표시.
+    * ex: **스택 트레이스**가 함께 기록되어 예외 발생 경로와 원인까지 확인할 수 있습니다.
+
+- **응답생성**
+    - 예외의 상태 코드를 사용하여 HTTP 응답 상태를 설정합니다. 저희 프로젝트 컨벤션에 맞춰 `ErrorStatus`를 400으로 생성하면, 항상 상태코드는 400으로 클라이언트에게 전달됩니다.
+    - `ApiResponse.onFailure()`: 오류 응답을 생성하는 정적 메서드를 사용하여, 실패 상태의 응답 객체를 생성합니다.
+
+- 추후 메소드 추가 가능성
+    - GeneralException 이외에도, Spring에서 정의한 예외를 잡기 위해, 해당 GlobalExceptionHandler 내에서 메소드를 추가하여 처리하도록 확장할 수 있습니다.
+
+---

--- a/src/main/java/icurriculum/domain/CategoryJudge/CategoryJudgeUtils.java
+++ b/src/main/java/icurriculum/domain/CategoryJudge/CategoryJudgeUtils.java
@@ -1,3 +1,4 @@
+/*
 package icurriculum.domain.categoryjudge;
 
 import icurriculum.domain.curriculum.Curriculum;
@@ -9,3 +10,4 @@ import java.util.Map;
 public interface CategoryJudgeUtils {
     Map<String,Category> judge(List<String> codes, Curriculum curriculum);
 }
+*/

--- a/src/main/java/icurriculum/domain/CategoryJudge/CategoryJudgeUtilsImpl.java
+++ b/src/main/java/icurriculum/domain/CategoryJudge/CategoryJudgeUtilsImpl.java
@@ -1,3 +1,4 @@
+/*
 package icurriculum.domain.categoryjudge;
 
 import icurriculum.domain.curriculum.Curriculum;
@@ -56,11 +57,13 @@ public class CategoryJudgeUtilsImpl implements CategoryJudgeUtils {
         return judgeCodes;
     }
 
-    /**
+    */
+/**
      * 사용자 핵심교양 판별 메서드
      *
      * @return 핵심교양 영역
-     **/
+     **//*
+
     public Category judgeCore(String code, Curriculum curriculum) {
 
         CoreJson coreJson = curriculum.getCoreJson(); // 핵심교양
@@ -130,9 +133,11 @@ public class CategoryJudgeUtilsImpl implements CategoryJudgeUtils {
 
 
     public Category judgeAlternative(Set<String> codes, Curriculum curriculum) {
-        /**
+        */
+/**
          * @params codes : 해당과목의 대체가능한 과목들
-         */
+         *//*
+
         CurriculumCodesJson curriculumCodesJson = curriculum.getCurriculumCodesJson(); // 교과과정
 
         Set<String> eMajor = curriculumCodesJson.findCodesByCategory(Category.전공필수);
@@ -167,3 +172,4 @@ public class CategoryJudgeUtilsImpl implements CategoryJudgeUtils {
     }
 
 }
+*/

--- a/src/main/java/icurriculum/domain/curriculum/data/Creativity.java
+++ b/src/main/java/icurriculum/domain/curriculum/data/Creativity.java
@@ -60,10 +60,13 @@ public class Creativity {
 
     public void validate() {
         if (requiredCredit == null) {
-            throw new GeneralException(ErrorStatus.CURRICULUM_MISSING_VALUE, this);
+            throw new GeneralException(ErrorStatus.CREATIVITY_INVALID_DATA, this);
         }
-        if (approvedCodeSet.isEmpty()) {
-            throw new GeneralException(ErrorStatus.CURRICULUM_MISSING_VALUE, this);
+        if (requiredCredit.equals(0) && !approvedCodeSet.isEmpty()) {
+            throw new GeneralException(ErrorStatus.CREATIVITY_INVALID_DATA, this);
+        }
+        if (!requiredCredit.equals(0) && approvedCodeSet.isEmpty()) {
+            throw new GeneralException(ErrorStatus.CREATIVITY_INVALID_DATA, this);
         }
     }
 }

--- a/src/main/java/icurriculum/domain/curriculum/data/SwAi.java
+++ b/src/main/java/icurriculum/domain/curriculum/data/SwAi.java
@@ -71,8 +71,14 @@ public class SwAi {
     }
 
     public void validate() {
-        if (approvedCodeSet.isEmpty() || requiredCredit == null) {
-            throw new GeneralException(ErrorStatus.CURRICULUM_MISSING_VALUE, this);
+        if (requiredCredit == null) {
+            throw new GeneralException(ErrorStatus.SW_AI_INVALID_DATA, this);
+        }
+        if (requiredCredit.equals(0) && !approvedCodeSet.isEmpty()) {
+            throw new GeneralException(ErrorStatus.SW_AI_INVALID_DATA, this);
+        }
+        if (!requiredCredit.equals(0) && approvedCodeSet.isEmpty()) {
+            throw new GeneralException(ErrorStatus.SW_AI_INVALID_DATA, this);
         }
     }
 

--- a/src/main/java/icurriculum/domain/graduation/service/module/MainGraduationService.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/MainGraduationService.java
@@ -119,7 +119,7 @@ public class MainGraduationService {
         CreditWithData majorSelectData = new CreditWithData(
             mainCurriculum.getMajorSelect(),
             mainCurriculum.getRequiredCredit().getSingleNeedCredit(),
-            majorRequiredDTO.getCompletedCredit()
+            majorRequiredDTO.completedCredit()
         );
 
         ProcessorResponse.MajorSelectDTO majorSelectDTO = executeProcessor(

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/core/CoreResult.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/core/CoreResult.java
@@ -1,0 +1,50 @@
+package icurriculum.domain.graduation.service.module.processor.core;
+
+import icurriculum.domain.curriculum.data.Core;
+import icurriculum.domain.take.Category;
+import icurriculum.domain.take.Take;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class CoreResult {
+
+    private int completedCredit; // 핵심교양 이수학점
+    private int requiredCredit; // 핵심교양 필요학점
+    private final Set<Category> uncompletedArea = new HashSet<>(); // 미이수 영역
+    private boolean isClear; // 조건 충족 여부
+
+    public void initUncompletedArea(Core core) {
+        uncompletedArea.addAll(core.getRequiredAreaSet());
+    }
+
+    public void update(
+        Take take,
+        Iterator<Take> iterator,
+        Category area,
+        boolean isAreaAlternative
+    ) {
+        completedCredit += take.getEffectiveCourse().getCredit();
+        uncompletedArea.remove(area);
+
+        if (!isAreaAlternative) {
+            iterator.remove();
+        }
+    }
+
+    public void setRequiredCredit(Core core) {
+        this.requiredCredit = core.getRequiredCredit();
+    }
+
+    public void checkIsClear(Core core) {
+        if (!core.getIsAreaFixed()) {
+            isClear = completedCredit >= requiredCredit;
+            return;
+        }
+        isClear = uncompletedArea.isEmpty();
+    }
+}

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/core/strategy/CommonCoreStrategy.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/core/strategy/CommonCoreStrategy.java
@@ -107,7 +107,7 @@ public class CommonCoreStrategy implements CoreStrategy {
     /*
      * [core logic]
      * - 영역 대체를 통해서 이미 계산된 과목은 건너뛴다.
-     * - 핵심교양으로 인정되는 과목은 LinkedList에서 삭제하고, response를 업데이트한다.
+     * - 핵심교양으로 인정되는 과목은 LinkedList에서 삭제하고, result 를 업데이트한다.
      */
     private void handleResult(
         Core core,

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/core/strategy/CommonCoreStrategy.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/core/strategy/CommonCoreStrategy.java
@@ -3,6 +3,8 @@ package icurriculum.domain.graduation.service.module.processor.core.strategy;
 import icurriculum.domain.course.Course;
 import icurriculum.domain.curriculum.data.AlternativeCourse;
 import icurriculum.domain.curriculum.data.Core;
+import icurriculum.domain.graduation.service.module.processor.core.CoreResult;
+import icurriculum.domain.graduation.service.module.processor.dto.ProcessorConverter;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorRequest;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorResponse;
 import icurriculum.domain.take.Category;
@@ -30,16 +32,25 @@ public class CommonCoreStrategy implements CoreStrategy {
         ProcessorRequest.CoreDTO request,
         LinkedList<Take> allTakeList
     ) {
-        ProcessorResponse.CoreDTO response = new ProcessorResponse.CoreDTO();
-        response.initUncompletedArea(request.core());
+        CoreResult result = new CoreResult();
+        result.initUncompletedArea(request.core());
 
         // 영역 대체 과목
-        Set<Course> areaAltCourseSet = handleAreaAlternative(allTakeList, request.core(),
-            request.alternativeCourse(), response);
+        Set<Course> areaAltCourseSet = handleAreaAlternative(
+            allTakeList,
+            request.core(),
+            request.alternativeCourse(),
+            result
+        );
 
-        handleResponse(request.core(), allTakeList, areaAltCourseSet, response);
+        handleResult(
+            request.core(),
+            allTakeList,
+            areaAltCourseSet,
+            result
+        );
 
-        return response;
+        return ProcessorConverter.to(result);
     }
 
 
@@ -55,7 +66,7 @@ public class CommonCoreStrategy implements CoreStrategy {
         LinkedList<Take> allTakeList,
         Core core,
         AlternativeCourse alternativeCourse,
-        ProcessorResponse.CoreDTO response
+        CoreResult result
     ) {
         Set<Course> areaAltCourseSet = new HashSet<>();
 
@@ -68,7 +79,7 @@ public class CommonCoreStrategy implements CoreStrategy {
                 Set<String> areaAlternativeCodeSet = core.getAreaAlternativeCodeSet(area);
 
                 if (GraduationUtils.isApproved(take, areaAlternativeCodeSet)) {
-                    response.update(take, iterator, area, true);
+                    result.update(take, iterator, area, true);
                     areaAltCourseSet.add(take.getEffectiveCourse());
                     continue;
                 }
@@ -78,7 +89,7 @@ public class CommonCoreStrategy implements CoreStrategy {
                     areaAlternativeCodeSet,
                     alternativeCourse)
                 ) {
-                    response.update(take, iterator, area, true);
+                    result.update(take, iterator, area, true);
                     areaAltCourseSet.add(take.getEffectiveCourse());
                 }
             }
@@ -98,11 +109,11 @@ public class CommonCoreStrategy implements CoreStrategy {
      * - 영역 대체를 통해서 이미 계산된 과목은 건너뛴다.
      * - 핵심교양으로 인정되는 과목은 LinkedList에서 삭제하고, response를 업데이트한다.
      */
-    private void handleResponse(
+    private void handleResult(
         Core core,
         LinkedList<Take> allTakeList,
         Set<Course> areaAltCourseSet,
-        ProcessorResponse.CoreDTO response
+        CoreResult result
     ) {
         Iterator<Take> iterator = allTakeList.iterator();
         while (iterator.hasNext()) {
@@ -113,12 +124,12 @@ public class CommonCoreStrategy implements CoreStrategy {
             }
 
             if (isCategoryApprovedToCore(take.getCategory(), core)) {
-                response.update(take, iterator, take.getCategory(), false);
+                result.update(take, iterator, take.getCategory(), false);
             }
         }
 
-        response.setRequiredCredit(core);
-        response.checkIsClear(core);
+        result.setRequiredCredit(core);
+        result.checkIsClear(core);
     }
 
     private boolean isCategoryApprovedToCore(Category category, Core core) {

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/creativity/CreativityResult.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/creativity/CreativityResult.java
@@ -1,0 +1,30 @@
+package icurriculum.domain.graduation.service.module.processor.creativity;
+
+import icurriculum.domain.curriculum.data.Creativity;
+import icurriculum.domain.take.Take;
+import java.util.Iterator;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class CreativityResult {
+
+    int completedCredit; // 창의 이수학점
+    int requiredCredit; // 창의 필요학점
+    boolean isClear; // 조건 충족 여부
+
+    public void update(Take take, Iterator<Take> iterator) {
+        completedCredit += take.getEffectiveCourse().getCredit();
+        iterator.remove();
+    }
+
+    public void setRequiredCredit(Creativity creativity) {
+        requiredCredit = creativity.getRequiredCredit();
+    }
+
+    public void checkIsClear() {
+        isClear = completedCredit >= requiredCredit;
+    }
+}
+

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/creativity/strategy/CommonCreativityStrategy.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/creativity/strategy/CommonCreativityStrategy.java
@@ -2,6 +2,8 @@ package icurriculum.domain.graduation.service.module.processor.creativity.strate
 
 import icurriculum.domain.curriculum.data.AlternativeCourse;
 import icurriculum.domain.curriculum.data.Creativity;
+import icurriculum.domain.graduation.service.module.processor.creativity.CreativityResult;
+import icurriculum.domain.graduation.service.module.processor.dto.ProcessorConverter;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorRequest;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorResponse;
 import icurriculum.domain.take.Category;
@@ -24,30 +26,30 @@ public class CommonCreativityStrategy implements CreativityStrategy {
         ProcessorRequest.CreativityDTO request,
         LinkedList<Take> allTakeList
     ) {
-        ProcessorResponse.CreativityDTO response = new ProcessorResponse.CreativityDTO();
+        CreativityResult result = new CreativityResult();
 
-        handleResponse(
+        handleResult(
             allTakeList,
             request.creativity(),
             request.alternativeCourse(),
-            response
+            result
         );
 
-        return response;
+        return ProcessorConverter.to(result);
     }
 
-    private void handleResponse(
+    private void handleResult(
         LinkedList<Take> allTakeList,
         Creativity creativity,
         AlternativeCourse alternativeCourse,
-        ProcessorResponse.CreativityDTO response
+        CreativityResult result
     ) {
         Iterator<Take> iterator = allTakeList.iterator();
         while (iterator.hasNext()) {
             Take take = iterator.next();
 
             if (GraduationUtils.isApprovedCategory(take, Category.창의)) {
-                response.update(take, iterator);
+                result.update(take, iterator);
                 continue;
             }
 
@@ -56,12 +58,12 @@ public class CommonCreativityStrategy implements CreativityStrategy {
                 creativity.getApprovedCodeSet(),
                 alternativeCourse
             )) {
-                response.update(take, iterator);
+                result.update(take, iterator);
             }
         }
 
-        response.setRequiredCredit(creativity);
-        response.checkIsClear();
+        result.setRequiredCredit(creativity);
+        result.checkIsClear();
     }
 
 }

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/dto/ProcessorConverter.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/dto/ProcessorConverter.java
@@ -1,0 +1,76 @@
+package icurriculum.domain.graduation.service.module.processor.dto;
+
+import icurriculum.domain.graduation.service.module.processor.creativity.CreativityResult;
+import icurriculum.domain.graduation.service.module.processor.dto.ProcessorResponse.*;
+import icurriculum.domain.graduation.service.module.processor.core.CoreResult;
+import icurriculum.domain.graduation.service.module.processor.generalrequired.GeneralRequiredResult;
+import icurriculum.domain.graduation.service.module.processor.majorrequired.MajorRequiredResult;
+import icurriculum.domain.graduation.service.module.processor.majorselect.MajorSelectResult;
+import icurriculum.domain.graduation.service.module.processor.swai.SwAiResult;
+
+public abstract class ProcessorConverter {
+
+    public static ProcessorResponse.SwAiDTO to(
+        SwAiResult result
+    ) {
+        return new SwAiDTO(
+            result.getCompletedCredit(),
+            result.getRequiredCredit(),
+            result.isClear()
+        );
+    }
+
+    public static ProcessorResponse.CoreDTO to(
+        CoreResult result
+    ) {
+        return new CoreDTO(
+            result.getCompletedCredit(),
+            result.getRequiredCredit(),
+            result.getUncompletedArea(),
+            result.isClear()
+        );
+    }
+
+    public static ProcessorResponse.CreativityDTO to(
+        CreativityResult result
+    ) {
+        return new CreativityDTO(
+            result.getCompletedCredit(),
+            result.getRequiredCredit(),
+            result.isClear()
+        );
+    }
+
+    public static ProcessorResponse.GeneralRequiredDTO to(
+        GeneralRequiredResult result
+    ) {
+        return new GeneralRequiredDTO(
+            result.getCompletedCredit(),
+            result.getRequiredCredit(),
+            result.getUncompletedCourseSet(),
+            result.isClear()
+        );
+    }
+
+    public static ProcessorResponse.MajorRequiredDTO to(
+        MajorRequiredResult result
+    ) {
+        return new MajorRequiredDTO(
+            result.getCompletedCredit(),
+            result.getRequiredCredit(),
+            result.getUncompletedCourseList(),
+            result.isClear()
+        );
+    }
+
+    public static ProcessorResponse.MajorSelectDTO to(
+        MajorSelectResult result
+    ) {
+        return new MajorSelectDTO(
+            result.getTotalMajorCompletedCredit(),
+            result.getTotalMajorRequiredCredit(),
+            result.isClear()
+        );
+    }
+
+}

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/dto/ProcessorResponse.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/dto/ProcessorResponse.java
@@ -1,272 +1,55 @@
 package icurriculum.domain.graduation.service.module.processor.dto;
 
 import icurriculum.domain.course.Course;
-import icurriculum.domain.curriculum.data.Core;
-import icurriculum.domain.curriculum.data.Creativity;
-import icurriculum.domain.curriculum.data.SwAi;
-import icurriculum.domain.graduation.service.module.processor.dto.ProcessorRequest.CreditWithData;
 import icurriculum.domain.take.Category;
-import icurriculum.domain.take.Take;
-import icurriculum.global.util.CourseUtils;
-import icurriculum.global.util.GraduationUtils;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import lombok.Getter;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 public abstract class ProcessorResponse {
 
-    @Getter
-    @ToString
-    public static class SwAiDTO {
-
-        private int completedCredit; // swAi 이수학점
-        private int requiredCredit; // swAi 필요학점
-        private boolean isClear; // 조건 충족 여부
-
-        public void update(Take take, Iterator<Take> iterator, boolean isAreaAlternative) {
-            completedCredit += take.getEffectiveCourse().getCredit();
-
-            if (!isAreaAlternative) {
-                iterator.remove();
-            }
-        }
-
-        public void setRequiredCredit(SwAi swAi) {
-            requiredCredit = swAi.getRequiredCredit();
-        }
-
-        public void checkIsClear() {
-            isClear = completedCredit >= requiredCredit;
-        }
+    public record SwAiDTO(
+        int completedCredit,
+        int requiredCredit,
+        boolean isClear
+    ) {
     }
 
-    @Getter
-    @ToString
-    public static class CreativityDTO {
-
-        private int completedCredit; // 창의 이수학점
-        private int requiredCredit; // 창의 필요학점
-        private boolean isClear; // 조건 충족 여부
-
-        public void update(Take take, Iterator<Take> iterator) {
-            completedCredit += take.getEffectiveCourse().getCredit();
-            iterator.remove();
-        }
-
-        public void setRequiredCredit(Creativity creativity) {
-            requiredCredit = creativity.getRequiredCredit();
-        }
-
-        public void checkIsClear() {
-            isClear = completedCredit >= requiredCredit;
-        }
+    public record CreativityDTO(
+        int completedCredit,
+        int requiredCredit,
+        boolean isClear
+    ) {
     }
 
-    @Getter
-    @ToString
-    public static class CoreDTO {
-
-        private int completedCredit; // 핵심교양 이수학점
-        private int requiredCredit; // 핵심교양 필요학점
-        private final Set<Category> uncompletedArea = new HashSet<>(); // 미이수 영역
-        private boolean isClear; // 조건 충족 여부
-
-        public void initUncompletedArea(Core core) {
-            uncompletedArea.addAll(core.getRequiredAreaSet());
-        }
-
-        public void update(
-            Take take,
-            Iterator<Take> iterator,
-            Category area,
-            boolean isAreaAlternative
-        ) {
-            completedCredit += take.getEffectiveCourse().getCredit();
-            uncompletedArea.remove(area);
-
-            if (!isAreaAlternative) {
-                iterator.remove();
-            }
-        }
-
-        public void setRequiredCredit(Core core) {
-            this.requiredCredit = core.getRequiredCredit();
-        }
-
-        public void checkIsClear(Core core) {
-            if (!core.getIsAreaFixed()) {
-                isClear = completedCredit >= requiredCredit;
-                return;
-            }
-            isClear = uncompletedArea.isEmpty();
-        }
+    public record CoreDTO(
+        int completedCredit,
+        int requiredCredit,
+        Set<Category> uncompletedArea,
+        boolean isClear
+    ) {
     }
 
-    @ToString
-    public static class GeneralRequiredDTO {
-
-        /*
-         * 응답 값
-         */
-        @Getter
-        private int completedCredit; // 교양필수 이수학점
-        @Getter
-        private int requiredCredit; // 교양필수 필요학점
-        @Getter
-        private final Set<Course> uncompletedCourseSet = new HashSet<>(); // 미이수 과목
-        @Getter
-        boolean isClear; // 조건 충족 여부
-
-        /*
-         * 임시 데이터
-         */
-        private boolean isClearEnglishBasic; // 영어 기초 이수 여부
-        private boolean isClearEnglishAdvance; // 영어 심화 이수 여부
-        private final Map<String, Course> generalRequiredCourseMap = new HashMap<>(); // 교양필수 Course Map
-
-        public void initGeneralRequiredResponse(List<Course> generalRequiredCourseList) {
-            for (Course course : generalRequiredCourseList) {
-                generalRequiredCourseMap.put(course.getCode(), course);
-            }
-        }
-
-        public void update(Take take, String code, Iterator<Take> iterator, final int joinYear) {
-            completedCredit += take.getEffectiveCourse().getCredit();
-            generalRequiredCourseMap.remove(code);
-            updateEnglishStatus(take.getEffectiveCourse(), joinYear);
-            iterator.remove();
-        }
-
-        // 하드코딩, 추후 변경
-        public void setRequiredCredit(List<Course> generalRequiredCourseList, final int joinYear) {
-            int totalCredit = CourseUtils.calculateTotalCredit(generalRequiredCourseList);
-
-            if (GraduationUtils.isCurriculumChanged(joinYear)) {
-                requiredCredit = totalCredit - 6;
-                return;
-            }
-            requiredCredit = totalCredit - 12;
-        }
-
-        public void setUncompletedCourseList() {
-            uncompletedCourseSet.addAll(generalRequiredCourseMap.values());
-        }
-
-        public void checkIsClear(final int joinYear) {
-            handleEnglishIfTakenEnglish(joinYear);
-            isClear = uncompletedCourseSet.isEmpty();
-        }
-
-        private void updateEnglishStatus(Course takenCourse, final int joinYear) {
-            if (GraduationUtils.isBasicEnglishCourse(takenCourse)) {
-                isClearEnglishBasic = true;
-            }
-
-            if (GraduationUtils.isCurriculumChanged(joinYear)) {
-                return;
-            }
-
-            if (GraduationUtils.isAdvanceEnglishCourse(takenCourse)) {
-                isClearEnglishAdvance = true;
-            }
-        }
-
-        /*
-         * 영어 이수 확인 시 uncompletedCourseSet에서 영어 관련 과목 삭제
-         *
-         * - 입학년도에 따라 분기처리
-         */
-        private void handleEnglishIfTakenEnglish(final int joinYear) {
-            if (isClearEnglishBasic) {
-                GraduationUtils.removeBasicEnglishCourse(uncompletedCourseSet);
-            }
-
-            if (GraduationUtils.isCurriculumChanged(joinYear)) {
-                return;
-            }
-
-            if (isClearEnglishAdvance) {
-                GraduationUtils.removeAdvanceEnglishCourse(uncompletedCourseSet);
-            }
-        }
+    public record GeneralRequiredDTO(
+        int completedCredit,
+        int requiredCredit,
+        Set<Course> uncompletedCourseSet,
+        boolean isClear
+    ) {
     }
 
-
-    @ToString
-    public static class MajorRequiredDTO {
-
-        /*
-         * 응답값
-         */
-        @Getter
-        private int completedCredit; // 전공필수 이수학점
-        @Getter
-        private int requiredCredit; // 전공필수 필요학점
-        @Getter
-        private final List<Course> uncompletedCourseList = new ArrayList<>(); // 미이수 과목
-        @Getter
-        private boolean isClear; // 조건 충족 여부
-
-        /*
-         * 임시 데이터
-         */
-        private final Map<String, Course> majorRequiredCourseMap = new HashMap<>(); // 교양필수 Course Map
-
-        public void initMajorRequiredResponse(List<Course> majorRequiredCourseList) {
-            for (Course course : majorRequiredCourseList) {
-                majorRequiredCourseMap.put(course.getCode(), course);
-            }
-        }
-
-        public void update(Take take, String code, Iterator<Take> iterator) {
-            completedCredit += take.getEffectiveCourse().getCredit();
-            majorRequiredCourseMap.remove(code);
-            iterator.remove();
-        }
-
-        public void setUncompletedCourseList() {
-            uncompletedCourseList.addAll(majorRequiredCourseMap.values());
-        }
-
-        public void setRequiredCredit(List<Course> generalRequiredCourseList) {
-            requiredCredit = CourseUtils.calculateTotalCredit(generalRequiredCourseList);
-        }
-
-        public void checkIsClear() {
-            isClear = uncompletedCourseList.isEmpty();
-        }
-
+    public record MajorRequiredDTO(
+        int completedCredit,
+        int requiredCredit,
+        List<Course> uncompletedCourseList,
+        boolean isClear
+    ) {
     }
 
-    @Getter
-    @ToString
-    public static class MajorSelectDTO {
-
-        private int totalMajorCompletedCredit; // 전공(전공선택 + 전공필수) 이수학점
-        private int totalMajorRequiredCredit; // 전공(전공선택 + 전공필수) 필요학점
-        private boolean isClear; // 조건 충족 여부
-
-        public void initMajorSelectResponse(CreditWithData creditWithData) {
-            totalMajorCompletedCredit += creditWithData.majorRequiredCompletedCredit();
-            totalMajorRequiredCredit += creditWithData.majorNeedCredit();
-        }
-
-        public void update(Take take, Iterator<Take> iterator) {
-            totalMajorCompletedCredit += take.getEffectiveCourse().getCredit();
-            iterator.remove();
-        }
-
-        public void checkIsClear() {
-            isClear = totalMajorCompletedCredit >= totalMajorRequiredCredit;
-        }
+    public record MajorSelectDTO(
+        int totalMajorCompletedCredit,
+        int totalMajorRequiredCredit,
+        boolean isClear
+    ) {
     }
 
 

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/generalrequired/GeneralRequiredResult.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/generalrequired/GeneralRequiredResult.java
@@ -1,0 +1,103 @@
+package icurriculum.domain.graduation.service.module.processor.generalrequired;
+
+import icurriculum.domain.course.Course;
+import icurriculum.domain.take.Take;
+import icurriculum.global.util.CourseUtils;
+import icurriculum.global.util.GraduationUtils;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+public class GeneralRequiredResult {
+
+    /*
+     * 응답 값
+     */
+    @Getter
+    private int completedCredit; // 교양필수 이수학점
+    @Getter
+    private int requiredCredit; // 교양필수 필요학점
+    @Getter
+    private final Set<Course> uncompletedCourseSet = new HashSet<>(); // 미이수 과목
+    @Getter
+    boolean isClear; // 조건 충족 여부
+
+    /*
+     * 임시 데이터
+     */
+    private boolean isClearEnglishBasic; // 영어 기초 이수 여부
+    private boolean isClearEnglishAdvance; // 영어 심화 이수 여부
+    private final Map<String, Course> generalRequiredCourseMap = new HashMap<>(); // 교양필수 Course Map
+
+    public void initGeneralRequiredResult(List<Course> generalRequiredCourseList) {
+        for (Course course : generalRequiredCourseList) {
+            generalRequiredCourseMap.put(course.getCode(), course);
+        }
+    }
+
+    public void update(Take take, String code, Iterator<Take> iterator, final int joinYear) {
+        completedCredit += take.getEffectiveCourse().getCredit();
+        generalRequiredCourseMap.remove(code);
+        updateEnglishStatus(take.getEffectiveCourse(), joinYear);
+        iterator.remove();
+    }
+
+    // 하드코딩, 추후 변경
+    public void setRequiredCredit(List<Course> generalRequiredCourseList, final int joinYear) {
+        int totalCredit = CourseUtils.calculateTotalCredit(generalRequiredCourseList);
+
+        if (GraduationUtils.isCurriculumChanged(joinYear)) {
+            requiredCredit = totalCredit - 6;
+            return;
+        }
+        requiredCredit = totalCredit - 12;
+    }
+
+    public void setUncompletedCourseList() {
+        uncompletedCourseSet.addAll(generalRequiredCourseMap.values());
+    }
+
+    public void checkIsClear(final int joinYear) {
+        handleEnglishIfTakenEnglish(joinYear);
+        isClear = uncompletedCourseSet.isEmpty();
+    }
+
+    private void updateEnglishStatus(Course takenCourse, final int joinYear) {
+        if (GraduationUtils.isBasicEnglishCourse(takenCourse)) {
+            isClearEnglishBasic = true;
+        }
+
+        if (GraduationUtils.isCurriculumChanged(joinYear)) {
+            return;
+        }
+
+        if (GraduationUtils.isAdvanceEnglishCourse(takenCourse)) {
+            isClearEnglishAdvance = true;
+        }
+    }
+
+    /*
+     * 영어 이수 확인 시 uncompletedCourseSet에서 영어 관련 과목 삭제
+     *
+     * - 입학년도에 따라 분기처리
+     */
+    private void handleEnglishIfTakenEnglish(final int joinYear) {
+        if (isClearEnglishBasic) {
+            GraduationUtils.removeBasicEnglishCourse(uncompletedCourseSet);
+        }
+
+        if (GraduationUtils.isCurriculumChanged(joinYear)) {
+            return;
+        }
+
+        if (isClearEnglishAdvance) {
+            GraduationUtils.removeAdvanceEnglishCourse(uncompletedCourseSet);
+        }
+    }
+}

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/generalrequired/strategy/CommonGeneralRequiredStrategy.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/generalrequired/strategy/CommonGeneralRequiredStrategy.java
@@ -3,9 +3,11 @@ package icurriculum.domain.graduation.service.module.processor.generalrequired.s
 import icurriculum.domain.course.Course;
 import icurriculum.domain.curriculum.data.AlternativeCourse;
 import icurriculum.domain.curriculum.data.GeneralRequired;
+import icurriculum.domain.graduation.service.module.processor.dto.ProcessorConverter;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorRequest;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorRequest.CourseListWithData;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorResponse;
+import icurriculum.domain.graduation.service.module.processor.generalrequired.GeneralRequiredResult;
 import icurriculum.domain.take.Take;
 import icurriculum.global.util.GraduationUtils;
 import java.util.Iterator;
@@ -33,28 +35,28 @@ public class CommonGeneralRequiredStrategy implements GeneralRequiredStrategy {
         ProcessorRequest.GeneralRequiredDTO request,
         LinkedList<Take> allTakeList
     ) {
-        ProcessorResponse.GeneralRequiredDTO response = new ProcessorResponse.GeneralRequiredDTO();
-        response.initGeneralRequiredResponse(
+        GeneralRequiredResult result = new GeneralRequiredResult();
+        result.initGeneralRequiredResult(
             request.CourseListWithData().essentialCourseList()
         );
 
-        handleResponse(
+        handleResult(
             allTakeList,
             request.CourseListWithData(),
             request.alternativeCourse(),
             request.joinYear(),
-            response
+            result
         );
 
-        return response;
+        return ProcessorConverter.to(result);
     }
 
-    private void handleResponse(
+    private void handleResult(
         LinkedList<Take> allTakeList,
         CourseListWithData<GeneralRequired> CourseListWithData,
         AlternativeCourse alternativeCourse,
         final int joinYear,
-        ProcessorResponse.GeneralRequiredDTO response
+        GeneralRequiredResult result
     ) {
         List<Course> generalRequiredCourseList = CourseListWithData.essentialCourseList();
         Set<String> generalRequiredCodeSet = CourseListWithData.data().getCodeSet();
@@ -64,20 +66,20 @@ public class CommonGeneralRequiredStrategy implements GeneralRequiredStrategy {
             Take take = iterator.next();
 
             if (GraduationUtils.isApproved(take, generalRequiredCodeSet)) {
-                response.update(take, take.getEffectiveCourse().getCode(), iterator, joinYear);
+                result.update(take, take.getEffectiveCourse().getCode(), iterator, joinYear);
                 continue;
             }
 
             GraduationUtils.getAlternativeCode(take, generalRequiredCodeSet, alternativeCourse)
                 .ifPresent(
-                    alternativeCode -> response.update(take, alternativeCode, iterator, joinYear)
+                    alternativeCode -> result.update(take, alternativeCode, iterator, joinYear)
                 );
 
         }
 
-        response.setRequiredCredit(generalRequiredCourseList, joinYear);
-        response.setUncompletedCourseList();
-        response.checkIsClear(joinYear);
+        result.setRequiredCredit(generalRequiredCourseList, joinYear);
+        result.setUncompletedCourseList();
+        result.checkIsClear(joinYear);
     }
 
 

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/majorrequired/MajorRequiredResult.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/majorrequired/MajorRequiredResult.java
@@ -1,0 +1,58 @@
+package icurriculum.domain.graduation.service.module.processor.majorrequired;
+
+import icurriculum.domain.course.Course;
+import icurriculum.domain.take.Take;
+import icurriculum.global.util.CourseUtils;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+public class MajorRequiredResult {
+
+    /*
+     * 응답값
+     */
+    @Getter
+    private int completedCredit; // 전공필수 이수학점
+    @Getter
+    private int requiredCredit; // 전공필수 필요학점
+    @Getter
+    private final List<Course> uncompletedCourseList = new ArrayList<>(); // 미이수 과목
+    @Getter
+    private boolean isClear; // 조건 충족 여부
+
+    /*
+     * 임시 데이터
+     */
+    private final Map<String, Course> majorRequiredCourseMap = new HashMap<>(); // 교양필수 Course Map
+
+    public void initMajorRequiredResult(List<Course> majorRequiredCourseList) {
+        for (Course course : majorRequiredCourseList) {
+            majorRequiredCourseMap.put(course.getCode(), course);
+        }
+    }
+
+    public void update(Take take, String code, Iterator<Take> iterator) {
+        completedCredit += take.getEffectiveCourse().getCredit();
+        majorRequiredCourseMap.remove(code);
+        iterator.remove();
+    }
+
+    public void setUncompletedCourseList() {
+        uncompletedCourseList.addAll(majorRequiredCourseMap.values());
+    }
+
+    public void setRequiredCredit(List<Course> generalRequiredCourseList) {
+        requiredCredit = CourseUtils.calculateTotalCredit(generalRequiredCourseList);
+    }
+
+    public void checkIsClear() {
+        isClear = uncompletedCourseList.isEmpty();
+    }
+
+}

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/majorrequired/strategy/CommonMajorRequiredStrategy.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/majorrequired/strategy/CommonMajorRequiredStrategy.java
@@ -3,9 +3,11 @@ package icurriculum.domain.graduation.service.module.processor.majorrequired.str
 import icurriculum.domain.course.Course;
 import icurriculum.domain.curriculum.data.AlternativeCourse;
 import icurriculum.domain.curriculum.data.MajorRequired;
+import icurriculum.domain.graduation.service.module.processor.dto.ProcessorConverter;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorRequest;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorRequest.CourseListWithData;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorResponse;
+import icurriculum.domain.graduation.service.module.processor.majorrequired.MajorRequiredResult;
 import icurriculum.domain.take.Take;
 import icurriculum.global.util.GraduationUtils;
 import java.util.Iterator;
@@ -22,26 +24,26 @@ public class CommonMajorRequiredStrategy implements MajorRequiredStrategy {
         ProcessorRequest.MajorRequiredDTO request,
         LinkedList<Take> allTakeList
     ) {
-        ProcessorResponse.MajorRequiredDTO response = new ProcessorResponse.MajorRequiredDTO();
-        response.initMajorRequiredResponse(
+        MajorRequiredResult result = new MajorRequiredResult();
+        result.initMajorRequiredResult(
             request.CourseListWithData().essentialCourseList()
         );
 
-        handleResponse(
+        handleResult(
             allTakeList,
             request.CourseListWithData(),
             request.alternativeCourse(),
-            response
+            result
         );
 
-        return response;
+        return ProcessorConverter.to(result);
     }
 
-    private void handleResponse(
+    private void handleResult(
         LinkedList<Take> allTakeList,
         CourseListWithData<MajorRequired> courseListWithData,
         AlternativeCourse alternativeCourse,
-        ProcessorResponse.MajorRequiredDTO response
+        MajorRequiredResult result
     ) {
 
         List<Course> majorRequiredCourseList = courseListWithData.essentialCourseList();
@@ -52,18 +54,18 @@ public class CommonMajorRequiredStrategy implements MajorRequiredStrategy {
             Take take = iterator.next();
 
             if (GraduationUtils.isApproved(take, majorRequiredCodeSet)) {
-                response.update(take, take.getEffectiveCourse().getCode(), iterator);
+                result.update(take, take.getEffectiveCourse().getCode(), iterator);
                 continue;
             }
             GraduationUtils.getAlternativeCode(take, majorRequiredCodeSet, alternativeCourse)
                 .ifPresent(
-                    alternativeCode -> response.update(take, alternativeCode, iterator)
+                    alternativeCode -> result.update(take, alternativeCode, iterator)
                 );
         }
 
-        response.setRequiredCredit(majorRequiredCourseList);
-        response.setUncompletedCourseList();
-        response.checkIsClear();
+        result.setRequiredCredit(majorRequiredCourseList);
+        result.setUncompletedCourseList();
+        result.checkIsClear();
     }
 
 }

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/majorselect/MajorSelectResult.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/majorselect/MajorSelectResult.java
@@ -1,0 +1,30 @@
+package icurriculum.domain.graduation.service.module.processor.majorselect;
+
+import icurriculum.domain.graduation.service.module.processor.dto.ProcessorRequest.CreditWithData;
+import icurriculum.domain.take.Take;
+import java.util.Iterator;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class MajorSelectResult {
+
+    private int totalMajorCompletedCredit; // 전공(전공선택 + 전공필수) 이수학점
+    private int totalMajorRequiredCredit; // 전공(전공선택 + 전공필수) 필요학점
+    private boolean isClear; // 조건 충족 여부
+
+    public void initMajorSelectResponse(CreditWithData creditWithData) {
+        totalMajorCompletedCredit += creditWithData.majorRequiredCompletedCredit();
+        totalMajorRequiredCredit += creditWithData.majorNeedCredit();
+    }
+
+    public void update(Take take, Iterator<Take> iterator) {
+        totalMajorCompletedCredit += take.getEffectiveCourse().getCredit();
+        iterator.remove();
+    }
+
+    public void checkIsClear() {
+        isClear = totalMajorCompletedCredit >= totalMajorRequiredCredit;
+    }
+}

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/majorselect/MajorSelectResult.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/majorselect/MajorSelectResult.java
@@ -14,7 +14,7 @@ public class MajorSelectResult {
     private int totalMajorRequiredCredit; // 전공(전공선택 + 전공필수) 필요학점
     private boolean isClear; // 조건 충족 여부
 
-    public void initMajorSelectResponse(CreditWithData creditWithData) {
+    public void initMajorSelectResult(CreditWithData creditWithData) {
         totalMajorCompletedCredit += creditWithData.majorRequiredCompletedCredit();
         totalMajorRequiredCredit += creditWithData.majorNeedCredit();
     }

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/majorselect/strategy/CommonMajorSelectStrategy.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/majorselect/strategy/CommonMajorSelectStrategy.java
@@ -30,7 +30,7 @@ public class CommonMajorSelectStrategy implements MajorSelectStrategy {
         LinkedList<Take> allTakeList
     ) {
         MajorSelectResult result = new MajorSelectResult();
-        result.initMajorSelectResponse(request.creditWithData());
+        result.initMajorSelectResult(request.creditWithData());
 
         handleResult(
             allTakeList,

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/majorselect/strategy/CommonMajorSelectStrategy.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/majorselect/strategy/CommonMajorSelectStrategy.java
@@ -1,9 +1,11 @@
 package icurriculum.domain.graduation.service.module.processor.majorselect.strategy;
 
 import icurriculum.domain.curriculum.data.AlternativeCourse;
+import icurriculum.domain.graduation.service.module.processor.dto.ProcessorConverter;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorRequest;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorRequest.CreditWithData;
 import icurriculum.domain.graduation.service.module.processor.dto.ProcessorResponse;
+import icurriculum.domain.graduation.service.module.processor.majorselect.MajorSelectResult;
 import icurriculum.domain.take.Category;
 import icurriculum.domain.take.Take;
 import icurriculum.global.util.GraduationUtils;
@@ -27,24 +29,24 @@ public class CommonMajorSelectStrategy implements MajorSelectStrategy {
         ProcessorRequest.MajorSelectDTO request,
         LinkedList<Take> allTakeList
     ) {
-        ProcessorResponse.MajorSelectDTO response = new ProcessorResponse.MajorSelectDTO();
-        response.initMajorSelectResponse(request.creditWithData());
+        MajorSelectResult result = new MajorSelectResult();
+        result.initMajorSelectResponse(request.creditWithData());
 
-        handleResponse(
+        handleResult(
             allTakeList,
             request.creditWithData(),
             request.alternativeCourse(),
-            response
+            result
         );
 
-        return response;
+        return ProcessorConverter.to(result);
     }
 
-    private void handleResponse(
+    private void handleResult(
         LinkedList<Take> allTakeList,
         CreditWithData creditWithData,
         AlternativeCourse alternativeCourse,
-        ProcessorResponse.MajorSelectDTO response
+        MajorSelectResult result
     ) {
         Set<String> majorSelectCodeSet = creditWithData.majorSelect().getCodeSet();
 
@@ -53,7 +55,7 @@ public class CommonMajorSelectStrategy implements MajorSelectStrategy {
             Take take = iterator.next();
 
             if (isCategoryGeneralRequired(take, majorSelectCodeSet)) {
-                response.update(take, iterator);
+                result.update(take, iterator);
                 continue;
             }
 
@@ -62,11 +64,11 @@ public class CommonMajorSelectStrategy implements MajorSelectStrategy {
                 majorSelectCodeSet,
                 alternativeCourse)
             ) {
-                response.update(take, iterator);
+                result.update(take, iterator);
             }
         }
 
-        response.checkIsClear();
+        result.checkIsClear();
     }
 
     /*

--- a/src/main/java/icurriculum/domain/graduation/service/module/processor/swai/SwAiResult.java
+++ b/src/main/java/icurriculum/domain/graduation/service/module/processor/swai/SwAiResult.java
@@ -1,0 +1,33 @@
+package icurriculum.domain.graduation.service.module.processor.swai;
+
+import icurriculum.domain.curriculum.data.SwAi;
+import icurriculum.domain.take.Take;
+import java.util.Iterator;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class SwAiResult {
+
+    private int completedCredit; // swAi 이수학점
+    private int requiredCredit; // swAi 필요학점
+    private boolean isClear; // 조건 충족 여부
+
+    public void update(Take take, Iterator<Take> iterator, boolean isAreaAlternative) {
+        completedCredit += take.getEffectiveCourse().getCredit();
+
+        if (!isAreaAlternative) {
+            iterator.remove();
+        }
+    }
+
+    public void setRequiredCredit(SwAi swAi) {
+        requiredCredit = swAi.getRequiredCredit();
+    }
+
+    public void checkIsClear() {
+        isClear = completedCredit >= requiredCredit;
+    }
+
+}

--- a/src/main/java/icurriculum/domain/take/CustomCourse.java
+++ b/src/main/java/icurriculum/domain/take/CustomCourse.java
@@ -16,7 +16,7 @@ import lombok.ToString;
 public class CustomCourse {
 
     @Column(name = "custom_code")
-    private String code;
+    private final String code = "CUSTOM";
 
     @Column(name = "custom_name")
     private String name;
@@ -25,8 +25,7 @@ public class CustomCourse {
     private Integer credit;
 
     @Builder
-    private CustomCourse(String code, String name, Integer credit) {
-        this.code = code;
+    private CustomCourse(String name, Integer credit) {
         this.name = name;
         this.credit = credit;
     }

--- a/src/main/java/icurriculum/global/response/status/ErrorStatus.java
+++ b/src/main/java/icurriculum/global/response/status/ErrorStatus.java
@@ -44,6 +44,10 @@ public enum ErrorStatus {
         "Curriculum 내부의 필수값이 빠졌습니다."),
     CURRICULUM_DECIDER_MISSING_VALUE(HttpStatus.BAD_REQUEST, "CURRICULUM406",
         "CurriculumDecider 내부의 필수값이 빠졌습니다."),
+    SW_AI_INVALID_DATA(HttpStatus.BAD_REQUEST, "CURRICULUM407",
+        "sw_ai의 데이터형식이 올바르지 않습니다."),
+    CREATIVITY_INVALID_DATA(HttpStatus.BAD_REQUEST, "CURRICULUM408",
+        "창의의 데이터형식이 올바르지 않습니다."),
 
     /*
      * category

--- a/src/main/java/icurriculum/testdata/컴퓨터공학과DataInitializer.java
+++ b/src/main/java/icurriculum/testdata/컴퓨터공학과DataInitializer.java
@@ -401,14 +401,14 @@ public class 컴퓨터공학과DataInitializer {
     public SwAi getSwAiJsonData() {
         return SwAi.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 
     public Creativity getCreativityJsonData() {
         return Creativity.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 

--- a/src/main/java/icurriculum/testdata/컴퓨터공학과DataInitializer.java
+++ b/src/main/java/icurriculum/testdata/컴퓨터공학과DataInitializer.java
@@ -358,13 +358,13 @@ public class 컴퓨터공학과DataInitializer {
             // 2023학년도 동계학기
             Take.builder().category(교양선택).takenYear("2023").takenSemester("동계").majorType(주전공)
                 .customCourse(
-                    CustomCourse.builder().code("AAO9017").name("현장실습 6").credit(6).build())
+                    CustomCourse.builder().name("현장실습 6").credit(6).build())
                 .member(member).build(),
 
             // 2024학년도 1학기
             Take.builder().category(전공선택).takenYear("2024").takenSemester("1").majorType(주전공)
                 .customCourse(
-                    CustomCourse.builder().code("CSE9318").name("현장실습 19").credit(18).build())
+                    CustomCourse.builder().name("현장실습 19").credit(18).build())
                 .member(member)
                 .build()
         );

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: icurriculum
   datasource:
-    url: jdbc:h2:tcp://localhost/~/project/i-curriculum/Back-end
+    url: jdbc:h2:tcp://localhost/~/project/localrdb/i-curriculum-db
     driver-class-name: org.h2.Driver
     username: sa
   jpa:

--- a/src/test/java/icurriculum/data/TestDataInitializer.java
+++ b/src/test/java/icurriculum/data/TestDataInitializer.java
@@ -399,13 +399,13 @@ public class TestDataInitializer {
             // 2023학년도 동계학기
             Take.builder().category(교양선택).takenYear("23").takenSemester("동계").majorType(주전공)
                 .customCourse(
-                    CustomCourse.builder().code("CUSTOM").name("현장실습 6").credit(6).build()
+                    CustomCourse.builder().name("현장실습 6").credit(6).build()
                 ).member(member).build(),
 
             // 2024학년도 1학기
             Take.builder().category(전공선택).takenYear("24").takenSemester("1").majorType(주전공)
                 .customCourse(
-                    CustomCourse.builder().code("CUSTOM").name("현장실습 18").credit(18).build()
+                    CustomCourse.builder().name("현장실습 18").credit(18).build()
                 ).member(member).build()
         );
     }

--- a/src/test/java/icurriculum/data/컴공18LData.java
+++ b/src/test/java/icurriculum/data/컴공18LData.java
@@ -378,7 +378,6 @@ public class 컴공18LData {
                 .customCourse(
                     CustomCourse.builder()
                         .name("IPP 현장실습")
-                        .code("CUSTOM")
                         .credit(12)
                         .build()
                 )

--- a/src/test/java/icurriculum/data/컴공18LData.java
+++ b/src/test/java/icurriculum/data/컴공18LData.java
@@ -426,14 +426,14 @@ public class 컴공18LData {
     public SwAi getSwAiJsonData() {
         return SwAi.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 
     public Creativity getCreativityJsonData() {
         return Creativity.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 

--- a/src/test/java/icurriculum/data/컴공19BData.java
+++ b/src/test/java/icurriculum/data/컴공19BData.java
@@ -421,14 +421,14 @@ public class 컴공19BData {
     public SwAi getSwAiJsonData() {
         return SwAi.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 
     public Creativity getCreativityJsonData() {
         return Creativity.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 

--- a/src/test/java/icurriculum/data/컴공19LData.java
+++ b/src/test/java/icurriculum/data/컴공19LData.java
@@ -408,14 +408,14 @@ public class 컴공19LData {
     public SwAi getSwAiJsonData() {
         return SwAi.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 
     public Creativity getCreativityJsonData() {
         return Creativity.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 

--- a/src/test/java/icurriculum/data/컴공19LData.java
+++ b/src/test/java/icurriculum/data/컴공19LData.java
@@ -352,7 +352,6 @@ public class 컴공19LData {
                 .customCourse(
                     CustomCourse.builder()
                         .credit(6)
-                        .code("CUSTOM")
                         .name("현장실습 6")
                         .build()
                 )
@@ -366,7 +365,6 @@ public class 컴공19LData {
                 .customCourse(
                     CustomCourse.builder()
                         .credit(18)
-                        .code("CUSTOM")
                         .name("현장실습 18")
                         .build())
                 .member(member).build()

--- a/src/test/java/icurriculum/data/컴공20KData.java
+++ b/src/test/java/icurriculum/data/컴공20KData.java
@@ -367,14 +367,14 @@ public class 컴공20KData {
     public SwAi getSwAiJsonData() {
         return SwAi.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 
     public Creativity getCreativityJsonData() {
         return Creativity.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 

--- a/src/test/java/icurriculum/data/컴공22LData.java
+++ b/src/test/java/icurriculum/data/컴공22LData.java
@@ -393,7 +393,7 @@ public class 컴공22LData {
     public SwAi getSwAiJsonData() {
         return SwAi.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 

--- a/src/test/java/icurriculum/data/컴공22LSJata.java
+++ b/src/test/java/icurriculum/data/컴공22LSJata.java
@@ -388,7 +388,7 @@ public class 컴공22LSJata {
     public SwAi getSwAiJsonData() {
         return SwAi.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 

--- a/src/test/java/icurriculum/data/컴공22OData.java
+++ b/src/test/java/icurriculum/data/컴공22OData.java
@@ -352,7 +352,7 @@ public class 컴공22OData {
     public SwAi getSwAiJsonData() {
         return SwAi.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 

--- a/src/test/java/icurriculum/data/컴공22SData.java
+++ b/src/test/java/icurriculum/data/컴공22SData.java
@@ -323,7 +323,7 @@ public class 컴공22SData {
     public SwAi getSwAiJsonData() {
         return SwAi.builder()
             .requiredCredit(0)
-            .approvedCodeSet(Set.of("DUMMY"))
+            .approvedCodeSet(Set.of())
             .build();
     }
 

--- a/src/test/java/icurriculum/data/컴퓨터공학과DataInitializer.java
+++ b/src/test/java/icurriculum/data/컴퓨터공학과DataInitializer.java
@@ -353,13 +353,13 @@ public class 컴퓨터공학과DataInitializer {
             // 2023학년도 동계학기
             Take.builder().category(교양선택).takenYear("2023").takenSemester("동계").majorType(주전공)
                 .customCourse(
-                    CustomCourse.builder().code("AAO9017").name("현장실습 6").credit(6).build())
+                    CustomCourse.builder().name("현장실습 6").credit(6).build())
                 .member(member).build(),
 
             // 2024학년도 1학기
             Take.builder().category(전공선택).takenYear("2024").takenSemester("1").majorType(주전공)
                 .customCourse(
-                    CustomCourse.builder().code("CSE9318").name("현장실습 19").credit(18).build())
+                    CustomCourse.builder().name("현장실습 18").credit(18).build())
                 .member(member)
                 .build()
         );

--- a/src/test/java/icurriculum/domain/graduation/AllGraduationServiceTest.java
+++ b/src/test/java/icurriculum/domain/graduation/AllGraduationServiceTest.java
@@ -1,9 +1,17 @@
 package icurriculum.domain.graduation;
 
+import icurriculum.data.컴공18LData;
 import icurriculum.data.컴공19BData;
+import icurriculum.data.컴공19LData;
+import icurriculum.data.컴공20KData;
+import icurriculum.data.컴공22LData;
+import icurriculum.data.컴공22LSJata;
+import icurriculum.data.컴공22OData;
+import icurriculum.data.컴공22SData;
 import icurriculum.domain.graduation.service.AllGraduationService;
 import icurriculum.domain.member.Member;
 import icurriculum.domain.member.repository.MemberRepository;
+import icurriculum.testdata.컴퓨터공학과DataInitializer;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/icurriculum/domain/take/TakeTest.java
+++ b/src/test/java/icurriculum/domain/take/TakeTest.java
@@ -34,7 +34,6 @@ public class TakeTest {
 
         customCourse = CustomCourse.builder()
             .name("현장실습 18")
-            .code("CUSTOM")
             .credit(18)
             .build();
     }

--- a/src/test/java/icurriculum/domain/take/service/TakeServiceTest.java
+++ b/src/test/java/icurriculum/domain/take/service/TakeServiceTest.java
@@ -50,7 +50,6 @@ class TakeServiceTest {
             .build();
 
         customCourse = CustomCourse.builder()
-            .code("CUSTOM")
             .name("현장실습 18")
             .credit(18)
             .build();


### PR DESCRIPTION

## #️⃣ 요약 설명
- ProcessorResponse 수정
- Response 관련하여 클래스 네이밍을 DTO 를 Result 로 바꾸고, Converter 도입
- swAi, 창의 영역 validation 로직 수정
- CustomCourse의 code를 "CUSTOM"으로 고정시키기 위해 미리 필드에 초기화
- README.md 에 응답 및 예외 처리 전략 추가

## 📝 작업 내용

```java
@Getter
@ToString
public class CoreResult {

    private int completedCredit; // 핵심교양 이수학점
    private int requiredCredit; // 핵심교양 필요학점
    private final Set<Category> uncompletedArea = new HashSet<>(); // 미이수 영역
    private boolean isClear; // 조건 충족 여부

    public void initUncompletedArea(Core core) {
        uncompletedArea.addAll(core.getRequiredAreaSet());
    }
...
```
> Response 관련 DTO에 서비스 로직 포함되있기 때문에 도메인 객체로 만들어 분리하고 Result라는 이름으로 바꿈


<br></br>
```java
public abstract class ProcessorConverter {

    public static ProcessorResponse.SwAiDTO to(
        SwAiResult result
    ) {
        return new SwAiDTO(
            result.getCompletedCredit(),
            result.getRequiredCredit(),
            result.isClear()
        );
    }
...
```
> ProcessorCoverter를 만들었으며, converter를 통해 xxxResult라는 도메인 객체를 DTO로 convert 하여 리턴



<br></br>
```java
    public void validate() {
        if (requiredCredit == null) {
            throw new GeneralException(ErrorStatus.CREATIVITY_INVALID_DATA, this);
        }
        if (requiredCredit.equals(0) && !approvedCodeSet.isEmpty()) {
            throw new GeneralException(ErrorStatus.CREATIVITY_INVALID_DATA, this);
        }
        if (!requiredCredit.equals(0) && approvedCodeSet.isEmpty()) {
            throw new GeneralException(ErrorStatus.CREATIVITY_INVALID_DATA, this);
        }
    }
```

> SwAi, 창의 데이터 validation 로직 수정
> SwAi, 창의 데이터를 듣지 않아도 되는 사람은 ApprovedCodeSet이 비어도 됨. 반대로 들어야하는 사람은 채워져있어야함
  
<br></br>
```java
@Embeddable
@NoArgsConstructor(access = PROTECTED)
@Getter
@ToString
public class CustomCourse {

    @Column(name = "custom_code")
    private final String code = "CUSTOM";

    @Column(name = "custom_name")
    private String name;

    @Column(name = "custom_credit")
    private Integer credit;

    @Builder
    private CustomCourse(String name, Integer credit) {
        this.name = name;
        this.credit = credit;
    }
}
```
>CustomCourse의 code는 항상 "CUSTOM"으로 고정시키기 위해 미리 필드에 초기화함. 빌더로 code를 지정 불가




## 동작 확인

<img width="1449" alt="image" src="https://github.com/user-attachments/assets/70a5ffc0-4eb5-45a9-a4b2-5a76de4e2528">

> 통합테스트 코드 정상작동


## 💬 리뷰 요구사항(선택)

