### PR TITLE
 [Feat-7] : course 단일조회 로직 생성

### DIFF
--- a/src/main/java/icurriculum/domain/course/controller/CourseController.java
+++ b/src/main/java/icurriculum/domain/course/controller/CourseController.java
@@ -1,0 +1,36 @@
+package icurriculum.domain.course.controller;
+
+import icurriculum.domain.course.dto.CourseRequest;
+import icurriculum.domain.course.dto.CourseResponse.DetailInfoDTO;
+import icurriculum.domain.course.service.CourseService;
+import icurriculum.domain.member.Member;
+import icurriculum.domain.membermajor.MajorType;
+import icurriculum.domain.membermajor.MemberMajor;
+import icurriculum.domain.membermajor.service.MemberMajorService;
+import icurriculum.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/course")
+@RequiredArgsConstructor
+public class CourseController {
+
+    private final CourseService courseService;
+    private final MemberMajorService memberMajorService;
+
+    @GetMapping("/single")
+    public ApiResponse<DetailInfoDTO> getCourse(
+            Member member,
+            @RequestBody CourseRequest.SimpleInfoDTO request) {
+        MajorType majorType = MajorType.valueOf(request.getMajorType());
+        MemberMajor memberMajor = memberMajorService.getMemberMajorByMemberAndMajorType(member,majorType);
+        DetailInfoDTO course = courseService.getCourse(request.getCode(), memberMajor);
+
+        return ApiResponse.onSuccess(course);
+    }
+}

--- a/src/main/java/icurriculum/domain/course/dto/CourseConverter.java
+++ b/src/main/java/icurriculum/domain/course/dto/CourseConverter.java
@@ -1,0 +1,17 @@
+package icurriculum.domain.course.dto;
+
+import icurriculum.domain.course.Course;
+import icurriculum.domain.course.dto.CourseResponse;
+import icurriculum.domain.take.Category;
+
+public abstract class CourseConverter {
+    public static CourseResponse.DetailInfoDTO toCourseDetailInfo(Course course, Category category) {
+        return CourseResponse.DetailInfoDTO.builder()
+                .courseId(course.getId())
+                .name(course.getName())
+                .credit(course.getCredit())
+                .code(course.getCode())
+                .category(category.toString())
+                .build();
+    }
+}

--- a/src/main/java/icurriculum/domain/course/dto/CourseRequest.java
+++ b/src/main/java/icurriculum/domain/course/dto/CourseRequest.java
@@ -1,0 +1,18 @@
+package icurriculum.domain.course.dto;
+
+import icurriculum.domain.membermajor.MemberMajor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CourseRequest {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SimpleInfoDTO {
+        String code;
+        String majorType;
+    }
+}

--- a/src/main/java/icurriculum/domain/course/dto/CourseResponse.java
+++ b/src/main/java/icurriculum/domain/course/dto/CourseResponse.java
@@ -1,0 +1,21 @@
+package icurriculum.domain.course.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public abstract class CourseResponse {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailInfoDTO {
+        private Long courseId;
+        private String name;
+        private Integer credit;
+        private String code;
+        private String category;
+    }
+
+}

--- a/src/main/java/icurriculum/domain/course/service/CourseService.java
+++ b/src/main/java/icurriculum/domain/course/service/CourseService.java
@@ -1,9 +1,19 @@
 package icurriculum.domain.course.service;
 
+import icurriculum.domain.categoryjudge.CategoryJudgeUtils;
 import icurriculum.domain.course.Course;
+import icurriculum.domain.course.dto.CourseConverter;
+import icurriculum.domain.course.dto.CourseResponse.DetailInfoDTO;
 import icurriculum.domain.course.repository.CourseRepository;
-import java.util.List;
-import java.util.Set;
+
+import java.util.*;
+
+import icurriculum.domain.curriculum.Curriculum;
+import icurriculum.domain.curriculum.service.CurriculumService;
+import icurriculum.domain.membermajor.MemberMajor;
+import icurriculum.domain.take.Category;
+import icurriculum.global.response.exception.GeneralException;
+import icurriculum.global.response.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,8 +24,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class CourseService {
 
     private final CourseRepository repository;
+    private final CurriculumService curriculumService;
 
     public List<Course> getCourseListByCodeSet(Set<String> codes) {
         return repository.findByCodeSet(codes);
+    }
+
+    public DetailInfoDTO getCourse(String code, MemberMajor memberMajor) {
+        Optional<Course> course = repository.findByCode(code);
+        /**
+         * todo : error 처리 수
+         */
+        if (course.isEmpty()) throw new GeneralException(ErrorStatus.COURSE_IS_NOT_VALID, this);
+        Course findCourse = course.get();
+        ArrayList<String> codes = new ArrayList<>();
+        codes.add(code);
+        Curriculum curriculum = curriculumService.getCurriculumByMemberMajor(memberMajor);
+        curriculum.validate();
+        Map<String, Category> judgedCodes = CategoryJudgeUtils.judge(codes, curriculum);
+        return CourseConverter.toCourseDetailInfo(findCourse, judgedCodes.get(code));
     }
 }


### PR DESCRIPTION
단일 조회용 service, controller, dto 등 생성했습니다.

Resolves: #7

## #️⃣ 요약 설명
course 조회를 하면 Category를 분류하여 courseId, name, credit, code, 분류된 category 를 dto에 담아 반환하도록 했습니다.

## 📝 작업 내용
controller 생성
response, request dto 생성
service 생성

```java
public DetailInfoDTO getCourse(String code, MemberMajor memberMajor) {
        Optional<Course> course = repository.findByCode(code);
        /**
         * todo : error 처리 수
         */
        if (course.isEmpty()) throw new GeneralException(ErrorStatus.COURSE_IS_NOT_VALID, this);
        Course findCourse = course.get();
        ArrayList<String> codes = new ArrayList<>();
        codes.add(code);
        Curriculum curriculum = curriculumService.getCurriculumByMemberMajor(memberMajor);
        curriculum.validate();
        Map<String, Category> judgedCodes = CategoryJudgeUtils.judge(codes, curriculum);
        return CourseConverter.toCourseDetailInfo(findCourse, judgedCodes.get(code));
    }
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
