### PR TITLE
[FEAT-59] 회원 정보 조회 api 구현

### DIFF
--- a/src/main/java/icurriculum/domain/member/Service/MemberService.java
+++ b/src/main/java/icurriculum/domain/member/Service/MemberService.java
@@ -5,8 +5,8 @@ import icurriculum.domain.department.repository.DepartmentRepository;
 import icurriculum.domain.member.Member;
 import icurriculum.domain.member.dto.MemberConverter;
 import icurriculum.domain.member.dto.MemberRequest;
+import icurriculum.domain.member.dto.MemberResponse;
 import icurriculum.domain.member.repository.MemberRepository;
-import icurriculum.domain.membermajor.MajorType;
 import icurriculum.domain.membermajor.MemberMajor;
 import icurriculum.domain.membermajor.MemberMajorConverter;
 import icurriculum.domain.membermajor.repository.MemberMajorRepository;
@@ -19,6 +19,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -68,6 +69,12 @@ public class MemberService {
         return memberRepository.findByEmail(email).orElseThrow(
                 () -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND_BY_EMAIL)
         );
+    }
+
+    @Transactional
+    public MemberResponse.MemberInfo getMemberInfo(Member member) {
+        List<MemberMajor> deptList = memberMajorRepository.findByMember(member);
+        return memberConverter.toMemberInfo(member, deptList);
     }
 
 }

--- a/src/main/java/icurriculum/domain/member/controller/MemberController.java
+++ b/src/main/java/icurriculum/domain/member/controller/MemberController.java
@@ -6,12 +6,13 @@ import icurriculum.domain.member.dto.MemberConverter;
 import icurriculum.domain.member.dto.MemberRequest;
 import icurriculum.domain.member.dto.MemberResponse;
 import icurriculum.global.response.ApiResponse;
+import icurriculum.global.security.annotation.LoginMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,4 +29,17 @@ public class MemberController {
 
         return ApiResponse.onSuccess(joinResponse);
     }
+
+    @GetMapping("/info")
+    @Operation(summary = "회원 정보 조회 api", description = "현재 로그인한 회원의 정보를 반환하는 api입니다.<br>**반환 형식**<br>이름<br>이메일<br>입학년도(ex. 19, 20, 21)<br>전공 리스트([{전공 종류, 학과}])")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", description = "성공",
+            content = @Content(schema = @Schema(implementation = MemberResponse.MemberInfo.class))
+    )
+    public ApiResponse<MemberResponse.MemberInfo> getMemberInfo(@LoginMember Member member) {
+        MemberResponse.MemberInfo memberInfo = memberService.getMemberInfo(member);
+
+        return ApiResponse.onSuccess(memberInfo);
+    }
+
 }

--- a/src/main/java/icurriculum/domain/member/dto/MemberConverter.java
+++ b/src/main/java/icurriculum/domain/member/dto/MemberConverter.java
@@ -2,7 +2,10 @@ package icurriculum.domain.member.dto;
 
 import icurriculum.domain.member.Member;
 import icurriculum.domain.member.RoleType;
+import icurriculum.domain.membermajor.MemberMajor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class MemberConverter {
@@ -20,6 +23,26 @@ public class MemberConverter {
         return MemberResponse.JoinResponse.builder()
                 .email(member.getEmail())
                 .join_date(member.getCreatedAt())
+                .build();
+    }
+
+    public MemberResponse.MemberInfo toMemberInfo(Member member, List<MemberMajor> memberMajorList) {
+        List<MemberResponse.MajorInfo> majorList = memberMajorList.stream().map(
+                this::toMajorInfo
+        ).toList();
+
+        return MemberResponse.MemberInfo.builder()
+                .name(member.getName())
+                .email(member.getEmail())
+                .joinYear(member.getJoinYear() % 100)
+                .majorList(majorList)
+                .build();
+    }
+
+    public MemberResponse.MajorInfo toMajorInfo(MemberMajor memberMajor) {
+        return MemberResponse.MajorInfo.builder()
+                .majorType(memberMajor.getMajorType())
+                .departmentName(memberMajor.getDepartment().getName())
                 .build();
     }
 }

--- a/src/main/java/icurriculum/domain/member/dto/MemberResponse.java
+++ b/src/main/java/icurriculum/domain/member/dto/MemberResponse.java
@@ -1,14 +1,16 @@
 package icurriculum.domain.member.dto;
 
+import icurriculum.domain.department.DepartmentName;
+import icurriculum.domain.membermajor.MajorType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public abstract class MemberResponse {
-
     @Builder
     @Getter
     @NoArgsConstructor
@@ -16,5 +18,26 @@ public abstract class MemberResponse {
     public static class JoinResponse {
         String email;
         LocalDateTime join_date;
+    }
+
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfo {
+        String name;
+        String email;
+        Integer joinYear;
+        List<MajorInfo> majorList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MajorInfo {
+        MajorType majorType;
+        DepartmentName departmentName;
     }
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
회원 정보를 조회하는 api 입니다.
헤더에 함께 전송되는 토큰을 가지고 member를 조회하기 때문에 별도의 parameter는 없습니다.
## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
>
> ex) 기존 memberInfoDTO response 값에 생일을 추가했습니다.

```java
@Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class MemberInfo {
        String name;
        String email;
        Integer joinYear;
        List<MajorInfo> majorList;
    }

    @Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class MajorInfo {
        MajorType majorType;
        DepartmentName departmentName;
    }
```
추후에 부전공, 연계전공 등을 모두 포함하기 위해 두개의 dto를 사용해 결과를 반환합니다.

```java
public MemberResponse.MemberInfo toMemberInfo(Member member, List<MemberMajor> memberMajorList) {
        List<MemberResponse.MajorInfo> majorList = memberMajorList.stream().map(
                this::toMajorInfo
        ).toList();

        return MemberResponse.MemberInfo.builder()
                .name(member.getName())
                .email(member.getEmail())
                .joinYear(member.getJoinYear() % 100)
                .majorList(majorList)
                .build();
    }
```
와이어프레임 보면 학번에서 두자리만 나오게 되어있어서 반환도 뒤에 두자리만 되도록 처리하였습니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진
> 
> ex) swagger 사진
<img width="2217" alt="스크린샷 2024-12-19 14 59 31" src="https://github.com/user-attachments/assets/950b8419-f772-4d1a-b1b3-f70b17562e12" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
