### PR TITLE
[Feat-60] take, course, graduation-check swagger 작성, Course 데이터 추가 API 생성, take crud 수정

### DIFF
--- a/src/main/java/icurriculum/admin/config/exception/AdminGeneralException.java
+++ b/src/main/java/icurriculum/admin/config/exception/AdminGeneralException.java
@@ -1,0 +1,35 @@
+package icurriculum.admin.config.exception;
+
+import icurriculum.global.response.status.ErrorStatus;
+import lombok.Getter;
+
+@Getter
+public class AdminGeneralException extends RuntimeException {
+
+    private final ErrorStatus errorStatus;
+    private final Object data;
+
+    public AdminGeneralException(ErrorStatus errorStatus) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+        this.data = null;
+    }
+
+    public AdminGeneralException(ErrorStatus errorStatus, Object data) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+        this.data = data;
+    }
+
+    public AdminGeneralException(ErrorStatus errorStatus, Throwable cause) {
+        super(errorStatus.getMessage(), cause);
+        this.errorStatus = errorStatus;
+        this.data = null;
+    }
+
+    public AdminGeneralException(ErrorStatus errorStatus, Object data, Throwable cause) {
+        super(errorStatus.getMessage(), cause);
+        this.errorStatus = errorStatus;
+        this.data = data;
+    }
+}

--- a/src/main/java/icurriculum/admin/config/exception/handler/AdminGlobalExceptionHandler.java
+++ b/src/main/java/icurriculum/admin/config/exception/handler/AdminGlobalExceptionHandler.java
@@ -1,16 +1,15 @@
-package icurriculum.admin.config;
+package icurriculum.admin.config.exception.handler;
 
-import icurriculum.global.response.exception.GeneralException;
+import icurriculum.admin.config.exception.AdminGeneralException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
 
-
 @ControllerAdvice
-public class AdminGlobalControllerAdvice {
+public class AdminGlobalExceptionHandler {
 
-    @ExceptionHandler(GeneralException.class)
-    public ModelAndView handleGeneralException(GeneralException ex) {
+    @ExceptionHandler(AdminGeneralException.class)
+    public ModelAndView handleAdminGeneralException(AdminGeneralException ex) {
         ModelAndView modelAndView = new ModelAndView("error/errorPage");
 
         modelAndView.addObject("errorStatus", ex.getErrorStatus());

--- a/src/main/java/icurriculum/admin/service/AdminService.java
+++ b/src/main/java/icurriculum/admin/service/AdminService.java
@@ -1,5 +1,6 @@
 package icurriculum.admin.service;
 
+import icurriculum.admin.config.exception.AdminGeneralException;
 import icurriculum.admin.web.converter.CurriculumConverter;
 import icurriculum.admin.web.form.ModifyForm;
 import icurriculum.admin.web.form.ModifyParam;
@@ -24,7 +25,6 @@ import icurriculum.domain.curriculum.data.SwAi;
 import icurriculum.domain.curriculum.repository.CurriculumRepository;
 import icurriculum.domain.department.DepartmentName;
 import icurriculum.domain.membermajor.MajorType;
-import icurriculum.global.response.exception.GeneralException;
 import icurriculum.global.response.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,7 +64,7 @@ public class AdminService {
         );
 
         return repository.findByDecider(decider).orElseThrow(
-                () -> new GeneralException(ErrorStatus.CURRICULUM_NOT_FOUND)
+                () -> new AdminGeneralException(ErrorStatus.CURRICULUM_NOT_FOUND)
         );
     }
 

--- a/src/main/java/icurriculum/admin/web/AdminCourseController.java
+++ b/src/main/java/icurriculum/admin/web/AdminCourseController.java
@@ -1,0 +1,52 @@
+package icurriculum.admin.web;
+
+import icurriculum.admin.web.json.CourseDTO;
+import icurriculum.domain.course.Course;
+import icurriculum.domain.course.repository.CourseRepository;
+import icurriculum.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/course")
+@RequiredArgsConstructor
+@Validated
+public class AdminCourseController {
+
+    private final CourseRepository repository;
+
+    /*
+     * Course 데이터 삽입 API
+     * Front 호출 X
+     */
+    @PostMapping("/insert-bulk")
+    public ApiResponse<Void> insertCourses(
+            @RequestBody @Valid Map<String, CourseDTO> coursesDTO
+    ) {
+        List<Course> courses = convertToCourses(coursesDTO);
+        repository.saveAll(courses);
+
+        return ApiResponse.OK;
+    }
+
+    private List<Course> convertToCourses(Map<String, CourseDTO> coursesDTO){
+        return coursesDTO.values().stream()
+                .map(courseDTO -> Course.builder()
+                        .credit(courseDTO.getCredit().intValue())
+                        .name(courseDTO.getName())
+                        .code(courseDTO.getCode())
+                        .build()
+                )
+                .toList();
+    }
+
+}

--- a/src/main/java/icurriculum/admin/web/form/detail/CoreForm.java
+++ b/src/main/java/icurriculum/admin/web/form/detail/CoreForm.java
@@ -1,6 +1,6 @@
 package icurriculum.admin.web.form.detail;
 
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import icurriculum.admin.config.valid.annotation.ValidCategory;
 import icurriculum.admin.config.valid.annotation.ValidEntry;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/icurriculum/admin/web/form/detail/CreativityForm.java
+++ b/src/main/java/icurriculum/admin/web/form/detail/CreativityForm.java
@@ -1,6 +1,6 @@
 package icurriculum.admin.web.form.detail;
 
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import icurriculum.admin.config.valid.annotation.ValidEntry;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;

--- a/src/main/java/icurriculum/admin/web/form/detail/GeneralRequiredForm.java
+++ b/src/main/java/icurriculum/admin/web/form/detail/GeneralRequiredForm.java
@@ -1,6 +1,6 @@
 package icurriculum.admin.web.form.detail;
 
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import icurriculum.admin.config.valid.annotation.ValidEntry;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/icurriculum/admin/web/form/detail/MajorRequiredForm.java
+++ b/src/main/java/icurriculum/admin/web/form/detail/MajorRequiredForm.java
@@ -1,6 +1,6 @@
 package icurriculum.admin.web.form.detail;
 
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import icurriculum.admin.config.valid.annotation.ValidEntry;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/icurriculum/admin/web/form/detail/MajorSelectForm.java
+++ b/src/main/java/icurriculum/admin/web/form/detail/MajorSelectForm.java
@@ -1,6 +1,6 @@
 package icurriculum.admin.web.form.detail;
 
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import icurriculum.admin.config.valid.annotation.ValidEntry;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/icurriculum/admin/web/form/detail/SwAiForm.java
+++ b/src/main/java/icurriculum/admin/web/form/detail/SwAiForm.java
@@ -1,6 +1,6 @@
 package icurriculum.admin.web.form.detail;
 
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import icurriculum.admin.config.valid.annotation.ValidEntry;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;

--- a/src/main/java/icurriculum/admin/web/json/CourseDTO.java
+++ b/src/main/java/icurriculum/admin/web/json/CourseDTO.java
@@ -1,0 +1,22 @@
+package icurriculum.admin.web.json;
+
+import icurriculum.global.valid.annotation.Code;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class CourseDTO {
+
+    @Code
+    private String code;
+
+    @NotBlank
+    private String name;
+
+    @Min(1)
+    @Max(10)
+    private Double credit;
+
+}

--- a/src/main/java/icurriculum/domain/course/controller/CourseController.java
+++ b/src/main/java/icurriculum/domain/course/controller/CourseController.java
@@ -1,38 +1,84 @@
 package icurriculum.domain.course.controller;
 
-import icurriculum.domain.course.dto.CourseRequest;
+import icurriculum.domain.membermajor.MemberMajor;
+import icurriculum.global.valid.annotation.Code;
 import icurriculum.domain.course.dto.CourseResponse.DetailInfoDTO;
 import icurriculum.domain.course.service.CourseService;
 import icurriculum.domain.member.Member;
 import icurriculum.domain.membermajor.MajorType;
-import icurriculum.domain.membermajor.MemberMajor;
 import icurriculum.domain.membermajor.service.MemberMajorService;
 import icurriculum.global.response.ApiResponse;
 import icurriculum.global.security.annotation.LoginMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
+@Slf4j
 @RestController
 @RequestMapping("/course")
 @RequiredArgsConstructor
+@Validated
 public class CourseController {
 
     private final CourseService courseService;
     private final MemberMajorService memberMajorService;
 
-    @GetMapping("/single")
+    /*
+     * 현재는 주전공만 지원
+     * 다중전공 지원하면 API 수정
+     */
+    @GetMapping
+    @Operation(
+            summary = "과목 조회 및 카테고리 판별",
+            description = "학수번호를 통해 강좌 정보를 조회합니다. 올바른 학수번호 형식은 영어 3글자 + 숫자 4자리입니다. 과목 정보 및 사용자 전공에 따른 카테고리가 판별됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = DetailInfoDTO.class),
+                            examples = @ExampleObject(
+                                    value = "{\n  \"isSuccess\": true,\n  \"code\": \"COMMON200\",\n  \"message\": \"성공입니다.\",\n  \"result\": {\n    \"courseId\": 1,\n    \"name\": \"객체지향프로그래밍 1\",\n    \"credit\": 3,\n    \"code\": \"CSE1101\",\n    \"category\": \"전공필수\"\n  }\n}"))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "올바르지 않은 형식의 학수번호 요청",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\n  \"isSuccess\": false,\n  \"code\": \"COMMON400\",\n  \"message\": \"잘못된 요청입니다.\",\n  \"result\": [\n    \"getCourse.code: 학수번호의 형식에 맞지 않습니다. (e.g. ABC1234)\"\n  ]\n}"))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "DB에 존재하지 않는 학수번호 요청",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\n  \"isSuccess\": false,\n  \"code\": \"COURSE400\",\n  \"message\": \"존재하지 않는 course 입니다.\",\n  \"result\": {}\n}"))
+            )
+    })
     public ApiResponse<DetailInfoDTO> getCourse(
             @LoginMember Member member,
-            @RequestBody CourseRequest.SimpleInfoDTO request) {
-        MajorType majorType = MajorType.valueOf(request.getMajorType());
-        MemberMajor memberMajor = memberMajorService.getMemberMajorByMemberAndMajorType(member,
-                majorType);
-        DetailInfoDTO course = courseService.getCourse(request.getCode(), memberMajor);
+            @RequestParam @Code String code
+    ) {
+        MajorType majorType = MajorType.주전공;
+        MemberMajor memberMajor = memberMajorService
+                .getMemberMajorByMemberAndMajorType(member, majorType);
+        DetailInfoDTO course = courseService.getCourse(code, memberMajor);
 
         return ApiResponse.onSuccess(course);
     }
+
 }

--- a/src/main/java/icurriculum/domain/curriculum/dto/request/AlternativeCourseRequest.java
+++ b/src/main/java/icurriculum/domain/curriculum/dto/request/AlternativeCourseRequest.java
@@ -1,7 +1,7 @@
 package icurriculum.domain.curriculum.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import java.util.Map;
 import java.util.Set;
 

--- a/src/main/java/icurriculum/domain/curriculum/dto/request/CoreRequest.java
+++ b/src/main/java/icurriculum/domain/curriculum/dto/request/CoreRequest.java
@@ -1,7 +1,7 @@
 package icurriculum.domain.curriculum.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/icurriculum/domain/curriculum/dto/request/CreativityRequest.java
+++ b/src/main/java/icurriculum/domain/curriculum/dto/request/CreativityRequest.java
@@ -1,7 +1,7 @@
 package icurriculum.domain.curriculum.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/icurriculum/domain/curriculum/dto/request/GeneralRequiredRequest.java
+++ b/src/main/java/icurriculum/domain/curriculum/dto/request/GeneralRequiredRequest.java
@@ -1,7 +1,7 @@
 package icurriculum.domain.curriculum.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/icurriculum/domain/curriculum/dto/request/MajorRequiredRequest.java
+++ b/src/main/java/icurriculum/domain/curriculum/dto/request/MajorRequiredRequest.java
@@ -1,7 +1,7 @@
 package icurriculum.domain.curriculum.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/icurriculum/domain/curriculum/dto/request/MajorSelectRequest.java
+++ b/src/main/java/icurriculum/domain/curriculum/dto/request/MajorSelectRequest.java
@@ -1,7 +1,7 @@
 package icurriculum.domain.curriculum.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/icurriculum/domain/curriculum/dto/request/SwAiRequest.java
+++ b/src/main/java/icurriculum/domain/curriculum/dto/request/SwAiRequest.java
@@ -1,7 +1,7 @@
 package icurriculum.domain.curriculum.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import jakarta.validation.constraints.NotNull;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/icurriculum/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/icurriculum/domain/graduation/controller/GraduationController.java
@@ -3,35 +3,222 @@ package icurriculum.domain.graduation.controller;
 import icurriculum.domain.graduation.dto.GraduationResponse;
 import icurriculum.domain.graduation.service.AllGraduationService;
 import icurriculum.domain.member.Member;
-import icurriculum.domain.member.repository.MemberRepository;
 import icurriculum.global.response.ApiResponse;
 import icurriculum.global.security.annotation.LoginMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class GraduationController {
 
     private final AllGraduationService allGraduationService;
-    private final MemberRepository testMemberRepository; // 삭제 예정
 
-    @PostMapping("check-graduation")
+    @PostMapping("/check-graduation")
+    @Operation(
+            summary = "졸업 요건 확인",
+            description = "사용자의 졸업 요건 검사 확인. 응답에는 각 카테고리별 검사 결과 정보가 포함됩니다.\n\n" +
+                    "응답 예시와 상세설명:\n" +
+                    "<pre>{\n" +
+                    "  \"isSuccess\": true, // (성공 여부)\n" +
+                    "  \"code\": \"COMMON200\", // (응답 코드)\n" +
+                    "  \"message\": \"성공입니다.\", // (응답 메시지)\n" +
+                    "  \"result\": { // (결과 데이터)\n" +
+                    "    \"swAiDTO(SWAI 결과)\": {\n" +
+                    "      \"completedCredit(이수학점)\": 0,\n" +
+                    "      \"requiredCredit(필요학점)\": 0,\n" +
+                    "      \"isClear(성공여부)\": true\n" +
+                    "    },\n" +
+                    "    \"creativityDTO(창의 결과)\": {\n" +
+                    "      \"completedCredit(이수학점)\": 0,\n" +
+                    "      \"requiredCredit(필요학점)\": 3,\n" +
+                    "      \"isClear(성공여부)\": false\n" +
+                    "    },\n" +
+                    "    \"coreDTO(핵심교양 결과)\": {\n" +
+                    "      \"completedCredit(이수학점)\": 0,\n" +
+                    "      \"requiredCredit(필요학점)\": 12,\n" +
+                    "      \"uncompletedArea(미이수 영역)\": [\n" +
+                    "        \"핵심교양1\",\n" +
+                    "        \"핵심교양2\",\n" +
+                    "        \"핵심교양4\",\n" +
+                    "        \"핵심교양6\"\n" +
+                    "      ],\n" +
+                    "      \"isClear(성공여부)\": false\n" +
+                    "    },\n" +
+                    "    \"majorRequiredDTO(전공필수 결과)\": {\n" +
+                    "      \"completedCredit(이수학점)\": 0,\n" +
+                    "      \"requiredCredit(필요학점)\": 6,\n" +
+                    "      \"uncompletedCourseList(미이수 전공필수 과목)\": [\n" +
+                    "        {\n" +
+                    "          \"createdAt\": \"2024-12-21T04:21:13.185364\", // (생성 시간)\n" +
+                    "          \"id\": 493, // (과목 ID)\n" +
+                    "          \"code\": \"CSE4205\", // (과목 코드)\n" +
+                    "          \"name\": \"컴퓨터공학 종합설계\", // (과목 이름)\n" +
+                    "          \"credit\": 3 // (학점)\n" +
+                    "        },\n" +
+                    "        {\n" +
+                    "          \"createdAt\": \"2024-12-21T04:21:13.126\", // (생성 시간)\n" +
+                    "          \"id\": 488, // (과목 ID)\n" +
+                    "          \"code\": \"CSE1101\", // (과목 코드)\n" +
+                    "          \"name\": \"객체지향프로그래밍 1\", // (과목 이름)\n" +
+                    "          \"credit\": 3 // (학점)\n" +
+                    "        }\n" +
+                    "      ],\n" +
+                    "      \"isClear(성공여부)\": false\n" +
+                    "    },\n" +
+                    "    \"majorSelectDTO(전공선택 + 전공필수 학점 계산 결과)\": {\n" +
+                    "      \"totalMajorCompletedCredit(총 전공 이수학점)\": 0,\n" +
+                    "      \"totalMajorRequiredCredit(총 전공 필요학점)\": 65,\n" +
+                    "      \"isClear(성공 여부)\": false\n" +
+                    "    },\n" +
+                    "    \"generalRequiredDTO(교양필수 결과)\": {\n" +
+                    "      \"completedCredit(이수학점)\": 0,\n" +
+                    "      \"requiredCredit(필요학점)\": 27,\n" +
+                    "      \"uncompletedCourseSet(미이수 교양필수 과목)\": [\n" +
+                    "        {\n" +
+                    "          \"createdAt\": \"2024-12-23T16:02:34.950071\", // (생성 시간)\n" +
+                    "          \"id\": 5611, // (과목 ID)\n" +
+                    "          \"code\": \"GEB1126\", // (과목 코드)\n" +
+                    "          \"name\": \"문제해결을 위한 글쓰기\", // (과목 이름)\n" +
+                    "          \"credit\": 3 // (학점)\n" +
+                    "        }\n" +
+                    "      ],\n" +
+                    "      \"isClear(성공여부)\": false\n" +
+                    "    },\n" +
+                    "    \"totalCompletedCredit(총 이수학점)\": 0,\n" +
+                    "    \"totalNeedCredit(총 필요학점)\": 130,\n" +
+                    "    \"isOverTotalNeedCredit(총 필요학점 충족여부 결과)\": false\n" +
+                    "  }\n" +
+                    "}</pre>"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = GraduationResponse.AllDTO.class),
+                            examples = @ExampleObject(
+                                    value = "{\n" +
+                                            "  \"isSuccess\": true,\n" +
+                                            "  \"code\": \"COMMON200\",\n" +
+                                            "  \"message\": \"성공입니다.\",\n" +
+                                            "  \"result\": {\n" +
+                                            "    \"swAiDTO\": {\n" +
+                                            "      \"completedCredit\": 0,\n" +
+                                            "      \"requiredCredit\": 0,\n" +
+                                            "      \"isClear\": true\n" +
+                                            "    },\n" +
+                                            "    \"creativityDTO\": {\n" +
+                                            "      \"completedCredit\": 0,\n" +
+                                            "      \"requiredCredit\": 3,\n" +
+                                            "      \"isClear\": false\n" +
+                                            "    },\n" +
+                                            "    \"coreDTO\": {\n" +
+                                            "      \"completedCredit\": 0,\n" +
+                                            "      \"requiredCredit\": 12,\n" +
+                                            "      \"uncompletedArea\": [\n" +
+                                            "        \"핵심교양1\",\n" +
+                                            "        \"핵심교양2\",\n" +
+                                            "        \"핵심교양4\",\n" +
+                                            "        \"핵심교양6\"\n" +
+                                            "      ],\n" +
+                                            "      \"isClear\": false\n" +
+                                            "    },\n" +
+                                            "    \"majorRequiredDTO\": {\n" +
+                                            "      \"completedCredit\": 0,\n" +
+                                            "      \"requiredCredit\": 6,\n" +
+                                            "      \"uncompletedCourseList\": [\n" +
+                                            "        {\n" +
+                                            "          \"createdAt\": \"2024-12-21T04:21:13.185364\",\n"
+                                            +
+                                            "          \"id\": 493,\n" +
+                                            "          \"code\": \"CSE4205\",\n" +
+                                            "          \"name\": \"컴퓨터공학 종합설계\",\n" +
+                                            "          \"credit\": 3\n" +
+                                            "        },\n" +
+                                            "        {\n" +
+                                            "          \"createdAt\": \"2024-12-21T04:21:13.126\",\n"
+                                            +
+                                            "          \"id\": 488,\n" +
+                                            "          \"code\": \"CSE1101\",\n" +
+                                            "          \"name\": \"객체지향프로그래밍 1\",\n" +
+                                            "          \"credit\": 3\n" +
+                                            "        }\n" +
+                                            "      ],\n" +
+                                            "      \"isClear\": false\n" +
+                                            "    },\n" +
+                                            "    \"majorSelectDTO\": {\n" +
+                                            "      \"totalMajorCompletedCredit\": 0,\n" +
+                                            "      \"totalMajorRequiredCredit\": 65,\n" +
+                                            "      \"isClear\": false\n" +
+                                            "    },\n" +
+                                            "    \"generalRequiredDTO\": {\n" +
+                                            "      \"completedCredit\": 0,\n" +
+                                            "      \"requiredCredit\": 27,\n" +
+                                            "      \"uncompletedCourseSet\": [\n" +
+                                            "        {\n" +
+                                            "          \"createdAt\": \"2024-12-23T16:02:34.950071\",\n"
+                                            +
+                                            "          \"id\": 5611,\n" +
+                                            "          \"code\": \"GEB1126\",\n" +
+                                            "          \"name\": \"문제해결을 위한 글쓰기\",\n" +
+                                            "          \"credit\": 3\n" +
+                                            "        },\n" +
+                                            "        {\n" +
+                                            "          \"createdAt\": \"2024-12-23T16:02:33.112743\",\n"
+                                            +
+                                            "          \"id\": 5450,\n" +
+                                            "          \"code\": \"ACE2104\",\n" +
+                                            "          \"name\": \"통계학\",\n" +
+                                            "          \"credit\": 3\n" +
+                                            "        },\n" +
+                                            "        {\n" +
+                                            "          \"createdAt\": \"2024-12-23T16:02:32.71449\",\n"
+                                            +
+                                            "          \"id\": 5414,\n" +
+                                            "          \"code\": \"GEB1108\",\n" +
+                                            "          \"name\": \"의사소통 영어: 중급\",\n" +
+                                            "          \"credit\": 3\n" +
+                                            "        }\n" +
+                                            "      ],\n" +
+                                            "      \"isClear\": false\n" +
+                                            "    },\n" +
+                                            "    \"totalCompletedCredit\": 0,\n" +
+                                            "    \"totalNeedCredit\": 130,\n" +
+                                            "    \"isOverTotalNeedCredit\": false\n" +
+                                            "  }\n" +
+                                            "}"
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "Authorization 헤더 누락 시 403",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = "{\n  \"timestamp\": \"2024-12-23T07:19:11.432+00:00\",\n  \"status\": 403,\n  \"error\": \"Forbidden\",\n  \"path\": \"/check-graduation\"\n}"
+                            )
+                    )
+            )
+    })
+
     public ApiResponse<GraduationResponse.AllDTO> checkAll(
             @LoginMember Member member
     ) {
-
-        /**
-         * Todo
-         * 1. Argument 내에 회원 데이터가 들어와야 함.
-         * 2. 현재는 단일전공 기능만 제공, 추후 다른 전공상태도 제공
-         */
-
-        Member testMember = testMemberRepository.findById(2L).get(); // 삭제 예정
+        log.info("member:{}", member);
         return ApiResponse.onSuccess(
-                allGraduationService.executeAll(testMember)
+                allGraduationService.executeAll(member)
         );
     }
-
 }
+

--- a/src/main/java/icurriculum/domain/take/Take.java
+++ b/src/main/java/icurriculum/domain/take/Take.java
@@ -11,6 +11,7 @@ import icurriculum.domain.member.Member;
 import icurriculum.domain.membermajor.MajorType;
 import icurriculum.global.response.exception.GeneralException;
 import icurriculum.global.response.status.ErrorStatus;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -49,7 +50,7 @@ public class Take extends BaseRDBEntity {
     private String takenSemester;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id")
     @Getter
     private Member member;
 
@@ -57,7 +58,7 @@ public class Take extends BaseRDBEntity {
      * Course Table 에 존재하는 Take
      * - nullable
      */
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "course_id", nullable = true)
     private Course course;
 
@@ -160,7 +161,8 @@ public class Take extends BaseRDBEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getCategory(), takenYear, getGrade(), takenSemester, getEffectiveCourse(),
+        return Objects.hash(getId(), getCategory(), takenYear, getGrade(), takenSemester,
+                getEffectiveCourse(),
                 getMember(),
                 getMajorType());
     }

--- a/src/main/java/icurriculum/domain/take/controller/TakeController.java
+++ b/src/main/java/icurriculum/domain/take/controller/TakeController.java
@@ -2,13 +2,18 @@ package icurriculum.domain.take.controller;
 
 
 import icurriculum.domain.member.Member;
+import icurriculum.domain.member.dto.MemberResponse;
 import icurriculum.domain.take.Take;
 import icurriculum.domain.take.dto.TakeConverter;
 import icurriculum.domain.take.dto.TakeRequest;
+import icurriculum.domain.take.dto.TakeResponse;
 import icurriculum.domain.take.dto.TakeResponse.TakeListDTO;
 import icurriculum.domain.take.service.TakeService;
 import icurriculum.global.response.ApiResponse;
 import icurriculum.global.security.annotation.LoginMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +29,11 @@ public class TakeController {
 
     private final TakeService takeService;
 
+    @Operation(summary = "수강 정보 조회 api", description = "현재 회원의 수강정보를 반환하는 api입니다.<br>**반환 형식(리스트)**<br>과목ID<br>학수번호<br>과목명<br>과목영역<br>점수<br>전공상태")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", description = "성공",
+            content = @Content(schema = @Schema(implementation = TakeResponse.TakeListDTO.class))
+    )
     @GetMapping("/")
     public ApiResponse<TakeListDTO> getTake(@LoginMember Member member) {
 
@@ -33,7 +43,11 @@ public class TakeController {
         return ApiResponse.onSuccess(takes);
     }
 
-
+    @Operation(summary = "수강 과목 신청 api", description = "현재 회원의 수강정보를 추가하는 api입니다.<br>**반환 형식(리스트)**<br>과목ID<br>학수번호<br>과목명<br>과목영역<br>점수<br>전공상태")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", description = "성공",
+            content = @Content(schema = @Schema(implementation = TakeResponse.TakeListDTO.class))
+    )
     @PostMapping("/create")
     public ApiResponse<TakeListDTO> createTake(
             @LoginMember Member member,
@@ -45,7 +59,11 @@ public class TakeController {
         return ApiResponse.onSuccess(takes);
     }
 
-
+    @Operation(summary = "수강 정보 수정 api", description = "현재 회원의 수강정보를 수정하는 api입니다.<br>**반환 형식(리스트)**<br>과목ID<br>학수번호<br>과목명<br>과목영역<br>점수<br>전공상태")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", description = "성공",
+            content = @Content(schema = @Schema(implementation = TakeResponse.TakeListDTO.class))
+    )
     @PostMapping("/update")
     public ApiResponse<TakeListDTO> updateTake(
             @LoginMember Member member,
@@ -56,6 +74,11 @@ public class TakeController {
         return ApiResponse.onSuccess(takes);
     }
 
+    @Operation(summary = "수강 정보 삭제 api", description = "현재 회원의 수강정보를 삭제하는 api입니다.<br>**반환 형식(리스트)**<br>과목ID<br>학수번호<br>과목명<br>과목영역<br>점수<br>전공상태")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200", description = "성공",
+            content = @Content(schema = @Schema(implementation = TakeResponse.TakeListDTO.class))
+    )
     @PostMapping("/delete")
     public ApiResponse<TakeListDTO> deleteTake(
             @LoginMember Member member,

--- a/src/main/java/icurriculum/domain/take/controller/TakeController.java
+++ b/src/main/java/icurriculum/domain/take/controller/TakeController.java
@@ -6,6 +6,7 @@ import icurriculum.domain.member.dto.MemberResponse;
 import icurriculum.domain.take.Take;
 import icurriculum.domain.take.dto.TakeConverter;
 import icurriculum.domain.take.dto.TakeRequest;
+import icurriculum.domain.take.dto.TakeRequest.TakeCreateListDTO;
 import icurriculum.domain.take.dto.TakeResponse;
 import icurriculum.domain.take.dto.TakeResponse.TakeListDTO;
 import icurriculum.domain.take.service.TakeService;
@@ -29,6 +30,7 @@ public class TakeController {
 
     private final TakeService takeService;
 
+
     @Operation(summary = "수강 정보 조회 api", description = "현재 회원의 수강정보를 반환하는 api입니다.<br>**반환 형식(리스트)**<br>과목ID<br>학수번호<br>과목명<br>과목영역<br>점수<br>전공상태")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "200", description = "성공",
@@ -43,7 +45,7 @@ public class TakeController {
         return ApiResponse.onSuccess(takes);
     }
 
-    @Operation(summary = "수강 과목 신청 api", description = "현재 회원의 수강정보를 추가하는 api입니다.<br>**반환 형식(리스트)**<br>과목ID<br>학수번호<br>과목명<br>과목영역<br>점수<br>전공상태")
+    @Operation(summary = "수강 과목 신청 api", description = "현재 회원의 수강정보를 추가하는 api입니다.<br>**반환 형식(리스트)**<br>학수번호<br>과목명<br>과목영역<br>과목학점<br>점수<br>전공상태")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "200", description = "성공",
             content = @Content(schema = @Schema(implementation = TakeResponse.TakeListDTO.class))
@@ -59,7 +61,7 @@ public class TakeController {
         return ApiResponse.onSuccess(takes);
     }
 
-    @Operation(summary = "수강 정보 수정 api", description = "현재 회원의 수강정보를 수정하는 api입니다.<br>**반환 형식(리스트)**<br>과목ID<br>학수번호<br>과목명<br>과목영역<br>점수<br>전공상태")
+    @Operation(summary = "수강 정보 수정 api", description = "현재 회원의 수강정보를 수정하는 api입니다.<br>**반환 형식(리스트)**<br>과목ID<br>학수번호<br>과목명<br>과목영역<br>과목학점<br>점수<br>전공상태")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "200", description = "성공",
             content = @Content(schema = @Schema(implementation = TakeResponse.TakeListDTO.class))
@@ -69,12 +71,12 @@ public class TakeController {
             @LoginMember Member member,
             @RequestBody TakeRequest.TakeUpdateDTO takeUpdateDTO) {
 
-        TakeListDTO takes = takeService.upadateTakeByMember(member, takeUpdateDTO);
+        TakeListDTO takes = takeService.updateTakeByMember(member, takeUpdateDTO);
 
         return ApiResponse.onSuccess(takes);
     }
 
-    @Operation(summary = "수강 정보 삭제 api", description = "현재 회원의 수강정보를 삭제하는 api입니다.<br>**반환 형식(리스트)**<br>과목ID<br>학수번호<br>과목명<br>과목영역<br>점수<br>전공상태")
+    @Operation(summary = "수강 정보 삭제 api", description = "현재 회원의 수강정보를 삭제하는 api입니다.<br>**반환 형식(리스트)**<br>과목ID<br>학수번호<br>과목명<br>과목영역<br>과목학점<br>점수<br>전공상태")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "200", description = "성공",
             content = @Content(schema = @Schema(implementation = TakeResponse.TakeListDTO.class))

--- a/src/main/java/icurriculum/domain/take/dto/TakeConverter.java
+++ b/src/main/java/icurriculum/domain/take/dto/TakeConverter.java
@@ -5,6 +5,7 @@ import icurriculum.domain.member.Member;
 import icurriculum.domain.membermajor.MajorType;
 import icurriculum.domain.take.Category;
 import icurriculum.domain.take.CustomCourse;
+import icurriculum.domain.take.Grade;
 import icurriculum.domain.take.Take;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -13,54 +14,50 @@ public abstract class TakeConverter {
 
     public static TakeResponse.TakeListDTO toTakeList(List<Take> takes) {
         List<TakeResponse.TakeDTO> takeListDTOs = takes.stream()
-            .map(take -> {
-                Course effectiveCourse = take.getEffectiveCourse();
-                return TakeResponse.TakeDTO.builder()
-                    .takeId(take.getId())
-                    .name(effectiveCourse.getName())
-                    .credit(effectiveCourse.getCredit())
-                    .code(effectiveCourse.getCode())
-                    .category(take.getCategory().toString())
-                    .majorType(take.getMajorType().toString())
-                    .build();
-            })
-            .collect(Collectors.toList());
+                .map(take -> {
+                    Course effectiveCourse = take.getEffectiveCourse();
+                    return TakeResponse.TakeDTO.builder()
+                            .takeId(take.getId())
+                            .name(effectiveCourse.getName())
+                            .credit(effectiveCourse.getCredit())
+                            .code(effectiveCourse.getCode())
+                            .category(take.getCategory().toString())
+                            .majorType(take.getMajorType().toString())
+                            .grade(take.getGrade().getScore())
+                            .build();
+                })
+                .collect(Collectors.toList());
 
         return TakeResponse.TakeListDTO.builder()
-            .takeList(takeListDTOs)
-            .build();
+                .takeList(takeListDTOs)
+                .build();
     }
 
-    public static Take toCustomTakeEntity(Member member,TakeRequest.TakeCreateDTO takeCreateDTO){
+    public static Take toCustomTakeEntity(Member member, TakeRequest.TakeCreateDTO takeCreateDTO) {
         return Take.builder()
-            .category(Category.valueOf(takeCreateDTO.getCategory()))
-            .majorType(MajorType.valueOf(takeCreateDTO.getMajorType()))
-            .member(member)
-            .course(null)
-            .customCourse(CustomCourse.builder()
-                .name(takeCreateDTO.getName())
-                .credit(takeCreateDTO.getCredit())
-                .build())
-            .build();
+                .category(Category.valueOf(takeCreateDTO.getCategory()))
+                .majorType(MajorType.valueOf(takeCreateDTO.getMajorType()))
+                .member(member)
+                .course(null)
+                .grade(Grade.getGradeByScore(takeCreateDTO.getGrade()))
+                .customCourse(CustomCourse.builder()
+                        .name(takeCreateDTO.getName())
+                        .credit(takeCreateDTO.getCredit())
+                        .build())
+                .build();
     }
 
-    public static Take toTakeEntity(Member member,TakeRequest.TakeCreateDTO takeCreateDTO){
+    public static Take toTakeEntity(Member member, TakeRequest.TakeCreateDTO takeCreateDTO,
+            Course course) {
         return Take.builder()
-            .category(Category.valueOf(takeCreateDTO.getCategory()))
-            .majorType(MajorType.valueOf(takeCreateDTO.getMajorType()))
-            .member(member)
-            .course(Course.builder()
-                .code(takeCreateDTO.getCode())
-                .name(takeCreateDTO.getName())
-                .credit(takeCreateDTO.getCredit())
-                .build()
-            )
-            .customCourse(null)
-            .build();
+                .category(Category.valueOf(takeCreateDTO.getCategory()))
+                .majorType(MajorType.valueOf(takeCreateDTO.getMajorType()))
+                .member(member)
+                .grade(Grade.getGradeByScore(takeCreateDTO.getGrade()))
+                .course(course)
+                .customCourse(null)
+                .build();
     }
-
-
-
 
 
 }

--- a/src/main/java/icurriculum/domain/take/dto/TakeRequest.java
+++ b/src/main/java/icurriculum/domain/take/dto/TakeRequest.java
@@ -4,15 +4,20 @@ package icurriculum.domain.take.dto;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 public class TakeRequest {
 
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
-    public static class TakeCreateDTO{
+    @ToString
+    @Data
+    public static class TakeCreateDTO {
+
         String code;
         String name;
         String category;
@@ -20,10 +25,12 @@ public class TakeRequest {
         Double grade;
         Integer credit;
     }
+
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
-    public static class TakeUpdateDTO{
+    public static class TakeUpdateDTO {
+
         Long takeId;
         String code;
         String name;
@@ -37,7 +44,9 @@ public class TakeRequest {
     @NoArgsConstructor
     @Getter
     @Builder
-    public static class TakeCreateListDTO{
+    @ToString
+    public static class TakeCreateListDTO {
+
         List<TakeCreateDTO> takeCreateDTOList;
     }
 
@@ -45,7 +54,11 @@ public class TakeRequest {
     @AllArgsConstructor
     @NoArgsConstructor
     @Getter
-    public static class TakeDeleteDTO{
+    @ToString
+    public static class TakeDeleteDTO {
+
         Long takeId;
     }
+
+
 }

--- a/src/main/java/icurriculum/domain/take/dto/TakeResponse.java
+++ b/src/main/java/icurriculum/domain/take/dto/TakeResponse.java
@@ -7,17 +7,20 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public abstract class TakeResponse {
+
     @Getter
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class TakeDTO{
+    public static class TakeDTO {
+
         private long takeId;
         private String code;
         private String name;
         private String category;
         private int credit;
         private String majorType;
+        private Double grade;
     }
 
     @Getter
@@ -25,6 +28,7 @@ public abstract class TakeResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class TakeListDTO {
+
         private List<TakeDTO> takeList;
     }
 

--- a/src/main/java/icurriculum/domain/take/service/TakeService.java
+++ b/src/main/java/icurriculum/domain/take/service/TakeService.java
@@ -1,6 +1,8 @@
 package icurriculum.domain.take.service;
 
 
+import icurriculum.domain.course.Course;
+import icurriculum.domain.course.repository.CourseRepository;
 import icurriculum.domain.member.Member;
 import icurriculum.domain.membermajor.MajorType;
 import icurriculum.domain.take.Category;
@@ -28,6 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class TakeService {
 
     private final TakeRepository repository;
+    private final CourseRepository courseRepository;
+
 
     public List<Take> getTakeListByMember(Member member) {
         return repository.findByMember(member);
@@ -38,14 +42,15 @@ public class TakeService {
         return new LinkedList<>(TakeList);
     }
 
+    @Transactional
     public TakeResponse.TakeListDTO createTakeListByMember(
-        Member member,
-        TakeRequest.TakeCreateListDTO takeCreateListDTO) {
+            Member member,
+            TakeRequest.TakeCreateListDTO takeCreateListDTO) {
 
         Set<String> existedCodeSet = repository.findByMember(member).stream()
-            .map(Take -> Take.getEffectiveCourse().getCode())
-            .filter(code -> !code.equals("custom"))
-            .collect(Collectors.toSet());
+                .map(Take -> Take.getEffectiveCourse().getCode())
+                .filter(code -> !code.equals("CUSTOM"))
+                .collect(Collectors.toSet());
 
         for (TakeCreateDTO takeCreateDTO : takeCreateListDTO.getTakeCreateDTOList()) {
             if (existedCodeSet.contains(takeCreateDTO.getCode())) {
@@ -54,14 +59,19 @@ public class TakeService {
         }
 
         List<Take> takes = takeCreateListDTO.getTakeCreateDTOList().stream()
-            .map(dto -> {
-                if (TakeUtils.isCustomCode(dto.getCode())) {
-                    return TakeConverter.toCustomTakeEntity(member, dto);
-                } else {
-                    return TakeConverter.toTakeEntity(member, dto);
-                }
-            })
-            .collect(Collectors.toList());
+                .map(dto -> {
+
+                    if (TakeUtils.isCustomCode(dto.getCode())) {
+                        return TakeConverter.toCustomTakeEntity(member, dto);
+                    } else {
+                        Course course = courseRepository.findByCode(dto.getCode())
+                                .orElseThrow(() -> new GeneralException(
+                                        ErrorStatus.COURSE_IS_NOT_VALID));
+                        return TakeConverter.toTakeEntity(member, dto, course);
+                    }
+                })
+                .collect(Collectors.toList());
+
         repository.saveAll(takes);
 
         List<Take> takeList = repository.findByMember(member);
@@ -71,15 +81,18 @@ public class TakeService {
 
 
     @Transactional
-    public TakeResponse.TakeListDTO upadateTakeByMember(
-        Member member,
-        TakeRequest.TakeUpdateDTO takeUpdateDTO) {
-        Take take = repository.findById(takeUpdateDTO.getTakeId())
-            .orElseThrow(() -> new GeneralException(ErrorStatus.TAKE_NOT_EXIST));
+    public TakeResponse.TakeListDTO updateTakeByMember(
+            Member member,
+            TakeRequest.TakeUpdateDTO takeUpdateDTO) {
 
-        take.updateTakeInfo(Category.valueOf(takeUpdateDTO.getCategory()),
-            MajorType.valueOf(takeUpdateDTO.getMajorType()),
-            Grade.getGradeByScore(takeUpdateDTO.getGrade()));
+        Take take = repository.findById(takeUpdateDTO.getTakeId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.TAKE_NOT_EXIST));
+
+        take.updateTakeInfo(
+                Category.valueOf(takeUpdateDTO.getCategory()),
+                MajorType.to(takeUpdateDTO.getMajorType()),
+                Grade.getGradeByScore(takeUpdateDTO.getGrade())
+        );
 
         List<Take> takeList = repository.findByMember(member);
 
@@ -89,8 +102,8 @@ public class TakeService {
 
     @Transactional
     public TakeResponse.TakeListDTO deleteTakeByMember(
-        Member member,
-        TakeRequest.TakeDeleteDTO takeDeleteDTO) {
+            Member member,
+            TakeRequest.TakeDeleteDTO takeDeleteDTO) {
         repository.deleteById(takeDeleteDTO.getTakeId());
 
         List<Take> takeList = repository.findByMember(member);

--- a/src/main/java/icurriculum/global/response/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/icurriculum/global/response/exception/handler/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package icurriculum.global.response.exception.handler;
 import icurriculum.global.response.ApiResponse;
 import icurriculum.global.response.exception.GeneralException;
 import icurriculum.global.response.status.ErrorStatus;
+import jakarta.validation.ConstraintViolationException;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -30,21 +32,53 @@ public class GlobalExceptionHandler {
                 ));
     }
 
-    /*
-     * Todo MethodArgumentNotValidException 이 다른 상황에서도 발생하면 수정 해야함.
-     * validation, 학수번호 검증 에러 처리
-     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Object>> handleMethodArgumentNotValidException(
             MethodArgumentNotValidException ex
     ) {
-        log.error("Validation error: {}", ex.getMessage(), ex);
+        List<String> errorMessages = getValidationErrorMessages(ex);
+        log.error("Validation errors: {}", errorMessages, ex);
 
         return ResponseEntity
-                .status(ErrorStatus.CODE_IS_NOT_VALID.getHttpStatus())
+                .status(ErrorStatus.BAD_REQUEST.getHttpStatus())
                 .body(ApiResponse.onFailure(
-                        ErrorStatus.CODE_IS_NOT_VALID,
-                        ErrorStatus.CODE_IS_NOT_VALID.getMessage()
+                        ErrorStatus.BAD_REQUEST,
+                        errorMessages
                 ));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<Object>> handleConstraintViolationException(
+            ConstraintViolationException ex
+    ) {
+        List<String> errorMessages = getValidationErrorMessages(ex);
+        log.error("Validation errors: {}", errorMessages, ex);
+
+        return ResponseEntity
+                .status(ErrorStatus.BAD_REQUEST.getHttpStatus())
+                .body(ApiResponse.onFailure(
+                        ErrorStatus.BAD_REQUEST,
+                        errorMessages
+                ));
+    }
+
+    private List<String> getValidationErrorMessages(MethodArgumentNotValidException ex) {
+        return ex.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> {
+                    String field = fieldError.getField();       // 실패한 필드 이름
+                    String message = fieldError.getDefaultMessage(); // 검증 실패 메시지
+                    return field + ": " + message;
+                })
+                .toList();
+    }
+
+    private List<String> getValidationErrorMessages(ConstraintViolationException ex) {
+        return ex.getConstraintViolations().stream()
+                .map(violation -> {
+                    String field = violation.getPropertyPath().toString(); // 위반된 필드
+                    String message = violation.getMessage();              // 검증 실패 메시지
+                    return field + ": " + message;
+                })
+                .toList();
     }
 }

--- a/src/main/java/icurriculum/global/valid/annotation/Code.java
+++ b/src/main/java/icurriculum/global/valid/annotation/Code.java
@@ -1,6 +1,6 @@
-package icurriculum.admin.config.valid.annotation;
+package icurriculum.global.valid.annotation;
 
-import icurriculum.admin.config.valid.validator.CodeValidator;
+import icurriculum.global.valid.validator.CodeValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 import java.lang.annotation.Documented;

--- a/src/main/java/icurriculum/global/valid/validator/CodeValidator.java
+++ b/src/main/java/icurriculum/global/valid/validator/CodeValidator.java
@@ -1,6 +1,6 @@
-package icurriculum.admin.config.valid.validator;
+package icurriculum.global.valid.validator;
 
-import icurriculum.admin.config.valid.annotation.Code;
+import icurriculum.global.valid.annotation.Code;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import java.util.regex.Pattern;


### PR DESCRIPTION
## #️⃣ 요약 설명
- Swagger code 추가
- Course 데이터 삽입

## 📝 작업 내용
- Course, Take, Graduation-Check Swagger 작성
  - Course 데이터 삽입에 따른 기존의 문제들 해결
- Course 데이터 삽입 위한 bulk 연산 API 추가 -> 1회성이기 때문에 성능 신경쓰지 않고 작성


다른 Swagger 코드 및 course insert 코드는 생략합니다.
**CourseController는 Swagger 외에도 약간의 코드 수정이 있어 설명합니다.**

```java
 @GetMapping
    @Operation(
            summary = "과목 조회 및 카테고리 판별",
            description = "학수번호를 통해 강좌 정보를 조회합니다. 올바른 학수번호 형식은 영어 3글자 + 숫자 4자리입니다. 과목 정보 및 사용자 전공에 따른 카테고리가 판별됩니다."
    )
...

    public ApiResponse<DetailInfoDTO> getCourse(
            @LoginMember Member member,
            @RequestParam @Code String code
    ) {
        MajorType majorType = MajorType.주전공; // 현재는 주전공만 지원
        MemberMajor memberMajor = memberMajorService
                .getMemberMajorByMemberAndMajorType(member, majorType);
        DetailInfoDTO course = courseService.getCourse(code, memberMajor);

        return ApiResponse.onSuccess(course);
    }
```

- 현재 주전공만 지원
- **기존에는 code(학수번호) + majorType(전공상태)을 둘 다 보내 주어야 했음. 현재는 주전공만 지원하기 때문에, code만 보내주면 주전공을 기준으로 카테고리 판별 및 Course를 조회 합니다.**
- 또한 **Get 요청은 Body에 데이터(json)를 보내는 것 보다 쿼리 파라미터를 사용**합시다.

## 동작 확인

**Course 데이터 삽입**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/def94c58-3d7a-4d52-8950-5ee12746df0b" />  
  
**졸업요건 확인 Swagger**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3e2f2720-53e6-4f57-bbac-10f63b0744a5" />  
  
**Take Swagger**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/66d38acf-daf6-43a2-87f9-dd8a1839c0ad" />  

**Course Swagger**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2a83b2ab-3a58-4421-8363-9e25a88826d5" />  
  
## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
